### PR TITLE
Export HCL report as library

### DIFF
--- a/vtpm-snp/Cargo.toml
+++ b/vtpm-snp/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "vtpm-snp"
+
 [dependencies]
 bincode = "1"
 clap = { version = "4", features = ["derive"] }

--- a/vtpm-snp/src/certs.rs
+++ b/vtpm-snp/src/certs.rs
@@ -4,9 +4,11 @@
 use openssl::x509::X509;
 use reqwest::blocking::get as http_get;
 use reqwest::blocking::Client as http_client;
+use reqwest::StatusCode;
 use serde::Deserialize;
 use sev::firmware::guest::types::AttestationReport;
-use std::error::Error;
+use std::error::Error as StdError;
+use thiserror::Error;
 
 const KDS_CERT_SITE: &str = "https://kdsintf.amd.com";
 const IMDS_CERT_URL: &str = "http://169.254.169.254/metadata/THIM/amd/certification";
@@ -19,18 +21,36 @@ pub struct AmdChain {
     pub ark: X509,
 }
 
+#[derive(Error, Debug)]
+pub enum CertError {
+    #[error("openssl error")]
+    OpenSsl(#[from] openssl::error::ErrorStack),
+    #[error("ARK is not self-signed")]
+    ArkNotSelfSigned,
+    #[error("ASK is not signed by ARK")]
+    AskNotSignedByArk,
+    #[error("VCEK is not signed by ASK")]
+    VcekNotSignedByAsk,
+    #[error("AMD Cert Chain download failed with status code {0}")]
+    CertChainDownloadFailed(StatusCode),
+    #[error("VCEK download failed with status code {0}")]
+    VcekDownloadFailed(StatusCode),
+    #[error("HTTP error")]
+    Http(#[from] reqwest::Error),
+}
+
 impl AmdChain {
-    pub fn validate(&self) -> Result<(), Box<dyn Error>> {
+    pub fn validate(&self) -> Result<(), CertError> {
         let ark_pubkey = self.ark.public_key()?;
 
         let ark_signed = self.ark.verify(&ark_pubkey)?;
         if !ark_signed {
-            return Err("ARK is not self-signed".into());
+            return Err(CertError::ArkNotSelfSigned);
         }
 
         let ask_signed = self.ask.verify(&ark_pubkey)?;
         if !ask_signed {
-            return Err("ASK is not signed by ARK".into());
+            return Err(CertError::AskNotSignedByArk);
         }
 
         Ok(())
@@ -40,24 +60,23 @@ impl AmdChain {
 pub struct Vcek(pub X509);
 
 impl Vcek {
-    pub fn validate(&self, amd_chain: &AmdChain) -> Result<(), Box<dyn Error>> {
+    pub fn validate(&self, amd_chain: &AmdChain) -> Result<(), CertError> {
         let ask_pubkey = amd_chain.ask.public_key()?;
         let vcek_signed = self.0.verify(&ask_pubkey)?;
         if !vcek_signed {
-            return Err("VCEK is not signed by ASK".into());
+            return Err(CertError::VcekNotSignedByAsk);
         }
 
         Ok(())
     }
 }
 
-pub fn get_chain_from_amd() -> Result<AmdChain, Box<dyn Error>> {
+pub fn get_chain_from_amd() -> Result<AmdChain, CertError> {
     let url = format!("{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{KDS_CERT_CHAIN}");
     let resp = http_get(url)?;
     let status = resp.status();
     if status != 200 {
-        let err_str = format!("Failed to get certificate chain from AMD: HTTP {status}");
-        return Err(err_str.into());
+        return Err(CertError::CertChainDownloadFailed(status));
     }
     let bytes = resp.bytes()?;
     let certs = X509::stack_from_pem(&bytes)?;
@@ -78,7 +97,7 @@ fn hexify(bytes: &[u8]) -> String {
     hex_string
 }
 
-pub fn get_vcek_from_amd(report: &AttestationReport) -> Result<Vcek, Box<dyn Error>> {
+pub fn get_vcek_from_amd(report: &AttestationReport) -> Result<Vcek, CertError> {
     let hw_id = hexify(&report.chip_id);
     let url = format!(
         "{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{hw_id}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
@@ -91,8 +110,7 @@ pub fn get_vcek_from_amd(report: &AttestationReport) -> Result<Vcek, Box<dyn Err
     let resp = http_get(url)?;
     let status = resp.status();
     if status != 200 {
-        let err_str = format!("Failed to get VCEK from AMD: HTTP {status}");
-        return Err(err_str.into());
+        return Err(CertError::VcekDownloadFailed(status));
     }
     let bytes = resp.bytes()?;
     let cert = X509::from_der(&bytes)?;
@@ -106,7 +124,7 @@ struct ImdsResponse {
     certificate_chain: String,
 }
 
-pub fn get_from_imds() -> Result<(Vcek, AmdChain), Box<dyn Error>> {
+pub fn get_from_imds() -> Result<(Vcek, AmdChain), Box<dyn StdError>> {
     let client = http_client::new();
     let resp = client
         .get(IMDS_CERT_URL)
@@ -127,7 +145,7 @@ pub fn get_from_imds() -> Result<(Vcek, AmdChain), Box<dyn Error>> {
     Ok((vcek, cert_chain))
 }
 
-fn build_chain(bytes: &[u8]) -> Result<AmdChain, Box<dyn Error>> {
+fn build_chain(bytes: &[u8]) -> Result<AmdChain, Box<dyn StdError>> {
     let certs = X509::stack_from_pem(bytes)?;
 
     if certs.len() != 2 {

--- a/vtpm-snp/src/lib.rs
+++ b/vtpm-snp/src/lib.rs
@@ -1,0 +1,7 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+pub mod certs;
+pub mod hcl;
+pub mod report;
+pub mod vtpm;

--- a/vtpm-snp/src/report.rs
+++ b/vtpm-snp/src/report.rs
@@ -5,15 +5,30 @@ use super::certs::Vcek;
 use openssl::{ecdsa::EcdsaSig, sha::Sha384};
 use sev::firmware::guest::types::{AttestationReport, Signature};
 use std::error::Error;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ValidateError {
+    #[error("openssl error")]
+    OpenSsl(#[from] openssl::error::ErrorStack),
+    #[error("TCB data is not valid")]
+    Tcb,
+    #[error("Measurement signature is not valid")]
+    MeasurementSignature,
+    #[error("IO error")]
+    Io(#[from] std::io::Error),
+    #[error("bincode error")]
+    Bincode(#[from] Box<bincode::ErrorKind>),
+}
 
 pub trait Validateable {
-    fn validate(&self, vcek: &Vcek) -> Result<(), Box<dyn Error>>;
+    fn validate(&self, vcek: &Vcek) -> Result<(), ValidateError>;
 }
 
 impl Validateable for AttestationReport {
-    fn validate(&self, vcek: &Vcek) -> Result<(), Box<dyn Error>> {
+    fn validate(&self, vcek: &Vcek) -> Result<(), ValidateError> {
         if !is_tcb_data_valid(self) {
-            return Err("TCB data is not valid".into());
+            return Err(ValidateError::Tcb);
         }
 
         let report_sig: EcdsaSig = (&self.signature).try_into()?;
@@ -25,7 +40,7 @@ impl Validateable for AttestationReport {
         let base_message_digest = hasher.finish();
 
         if !report_sig.verify(&base_message_digest, &vcek_pubkey)? {
-            return Err("Measurement signature is not valid".into());
+            return Err(ValidateError::MeasurementSignature);
         }
         Ok(())
     }
@@ -40,7 +55,7 @@ fn is_tcb_data_valid(report: &AttestationReport) -> bool {
     report.reported_tcb == report.committed_tcb
 }
 
-fn get_report_base(report: &AttestationReport) -> Result<Vec<u8>, Box<dyn Error>> {
+fn get_report_base(report: &AttestationReport) -> Result<Vec<u8>, Box<bincode::ErrorKind>> {
     let report_len = std::mem::size_of::<AttestationReport>();
     let signature_len = std::mem::size_of::<Signature>();
     let bytes = bincode::serialize(report)?;


### PR DESCRIPTION
# Export HCL report as library

We want to use code as a library in attestation agent/service

- Use HCL report in binary
- Add lib
- Added more explicit error types
- Change return type for get_ak fn

## How to use

vtpm-snp should be used as a low-level library in attestation libraries. 

## Testing done

Tested the library in initial [cc_kbc](https://github.com/mkulke/attestation-agent/pull/1) & [attestation-service](https://github.com/mkulke/attestation-service/pull/1) code.
