### PR TITLE
Add feature flags for attester/verifier code

### DIFF
--- a/az-snp-vtpm/Cargo.toml
+++ b/az-snp-vtpm/Cargo.toml
@@ -14,17 +14,25 @@ path = "src/lib.rs"
 [[bin]]
 name = "snp-vtpm"
 path = "src/main.rs"
+required-features = ["attester", "verifier"]
 
 [dependencies]
 bincode = "1"
 clap = { version = "4", features = ["derive"] }
 jsonwebkey = { version = "0.3.5", features = ["pkcs-convert"] }
 memoffset = "0.8.0"
-openssl = { version = "0.10.45", features = ["vendored"] }
-reqwest = { version = "0.11", features = ["blocking"] }
+openssl = { version = "0.10.45", features = ["vendored"], optional = true }
+rsa = { version = "0.8.2", features = ["pkcs5", "sha2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sev = { version = "1", features = ["openssl"] }
+sev = "1"
+sha2 = "0.10.6"
 static_assertions = "^1.1.0"
 thiserror = "1.0.38"
 tss-esapi = "7.2"
+ureq = { version = "2.6.2", default-features = false, features = ["json"] }
+
+[features]
+default = ["attester", "verifier"]
+attester = []
+verifier = ["openssl", "sev/openssl", "ureq/tls"]

--- a/az-snp-vtpm/src/amd_kds.rs
+++ b/az-snp-vtpm/src/amd_kds.rs
@@ -1,0 +1,69 @@
+use crate::certs::{AmdChain, Vcek};
+use openssl::x509::X509;
+use sev::firmware::guest::types::AttestationReport;
+use thiserror::Error;
+
+const KDS_CERT_SITE: &str = "https://kdsintf.amd.com";
+const KDS_VCEK: &str = "/vcek/v1";
+const SEV_PROD_NAME: &str = "Milan";
+const KDS_CERT_CHAIN: &str = "cert_chain";
+
+#[derive(Error, Debug)]
+pub enum AmdKdsError {
+    #[error("HTTP error")]
+    Http(#[from] Box<ureq::Error>),
+    #[error("io error")]
+    Io(#[from] std::io::Error),
+}
+
+fn get(url: &str) -> Result<Vec<u8>, AmdKdsError> {
+    let mut body = ureq::get(url).call().map_err(Box::new)?.into_reader();
+    let mut buffer = Vec::new();
+    body.read_to_end(&mut buffer)?;
+    Ok(buffer)
+}
+
+#[derive(Error, Debug)]
+pub enum CertError {
+    #[error("openssl error")]
+    OpenSsl(#[from] openssl::error::ErrorStack),
+    #[error("AMD KDS error")]
+    AmdKdsError(#[from] AmdKdsError),
+}
+
+pub fn get_chain() -> Result<AmdChain, CertError> {
+    let url = format!("{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{KDS_CERT_CHAIN}");
+    let bytes = get(&url)?;
+
+    let certs = X509::stack_from_pem(&bytes)?;
+    let ask = certs[0].clone();
+    let ark = certs[1].clone();
+
+    let chain = AmdChain { ask, ark };
+
+    Ok(chain)
+}
+
+fn hexify(bytes: &[u8]) -> String {
+    let mut hex_string = String::new();
+    for byte in bytes {
+        hex_string.push_str(&format!("{:02x}", byte));
+    }
+    hex_string
+}
+
+pub fn get_vcek(report: &AttestationReport) -> Result<Vcek, CertError> {
+    let hw_id = hexify(&report.chip_id);
+    let url = format!(
+        "{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{hw_id}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
+        report.reported_tcb.boot_loader,
+        report.reported_tcb.tee,
+        report.reported_tcb.snp,
+        report.reported_tcb.microcode
+    );
+
+    let bytes = get(&url)?;
+    let cert = X509::from_der(&bytes)?;
+    let vcek = Vcek(cert);
+    Ok(vcek)
+}

--- a/az-snp-vtpm/src/certs.rs
+++ b/az-snp-vtpm/src/certs.rs
@@ -2,14 +2,8 @@
 // Licensed under the MIT License.
 
 use crate::imds;
-use openssl::x509::X509;
-use sev::firmware::guest::types::AttestationReport;
+pub use openssl::x509::X509;
 use thiserror::Error;
-
-const KDS_CERT_SITE: &str = "https://kdsintf.amd.com";
-const KDS_VCEK: &str = "/vcek/v1";
-const SEV_PROD_NAME: &str = "Milan";
-const KDS_CERT_CHAIN: &str = "cert_chain";
 
 pub struct AmdChain {
     pub ask: X509,
@@ -32,8 +26,6 @@ pub enum ValidateError {
 pub enum CertError {
     #[error("openssl error")]
     OpenSsl(#[from] openssl::error::ErrorStack),
-    #[error("AMD KDS error")]
-    AmdKdsError(#[from] AmdKdsError),
     #[error("IMDS error")]
     Imds(#[from] imds::ImdsError),
     #[error("parsing error")]
@@ -72,85 +64,6 @@ impl Vcek {
     }
 }
 
-pub struct AmdKds<'a>(&'a AttestationReport);
-
-#[derive(Error, Debug)]
-pub enum AmdKdsError {
-    #[error("HTTP error")]
-    Http(#[from] Box<ureq::Error>),
-    #[error("io error")]
-    Io(#[from] std::io::Error),
-}
-
-impl<'a> AmdKds<'a> {
-    pub fn new(report: &'a AttestationReport) -> Self {
-        Self(report)
-    }
-
-    fn get(&self, url: &str) -> Result<Vec<u8>, AmdKdsError> {
-        let mut body = ureq::get(url).call().map_err(Box::new)?.into_reader();
-        let mut buffer = Vec::new();
-        body.read_to_end(&mut buffer)?;
-        Ok(buffer)
-    }
-}
-
-pub trait CertProvider {
-    fn get_chain(&self) -> Result<AmdChain, CertError>;
-    fn get_vcek(&self) -> Result<Vcek, CertError>;
-}
-
-impl CertProvider for imds::Response {
-    fn get_chain(&self) -> Result<AmdChain, CertError> {
-        let chain = build_chain(self.certificate_chain.as_bytes())?;
-        Ok(chain)
-    }
-
-    fn get_vcek(&self) -> Result<Vcek, CertError> {
-        let vcek = Vcek(X509::from_pem(self.vcek_cert.as_bytes())?);
-        Ok(vcek)
-    }
-}
-
-impl<'a> CertProvider for AmdKds<'a> {
-    fn get_chain(&self) -> Result<AmdChain, CertError> {
-        let url = format!("{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{KDS_CERT_CHAIN}");
-        let bytes = self.get(&url)?;
-
-        let certs = X509::stack_from_pem(&bytes)?;
-        let ask = certs[0].clone();
-        let ark = certs[1].clone();
-
-        let chain = AmdChain { ask, ark };
-
-        Ok(chain)
-    }
-
-    fn get_vcek(&self) -> Result<Vcek, CertError> {
-        let hw_id = hexify(&self.0.chip_id);
-        let url = format!(
-            "{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{hw_id}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
-            self.0.reported_tcb.boot_loader,
-            self.0.reported_tcb.tee,
-            self.0.reported_tcb.snp,
-            self.0.reported_tcb.microcode
-        );
-
-        let bytes = self.get(&url)?;
-        let cert = X509::from_der(&bytes)?;
-        let vcek = Vcek(cert);
-        Ok(vcek)
-    }
-}
-
-fn hexify(bytes: &[u8]) -> String {
-    let mut hex_string = String::new();
-    for byte in bytes {
-        hex_string.push_str(&format!("{:02x}", byte));
-    }
-    hex_string
-}
-
 #[derive(Error, Debug)]
 pub enum ParseError {
     #[error("openssl error")]
@@ -159,7 +72,7 @@ pub enum ParseError {
     WrongAmount(usize, usize),
 }
 
-fn build_chain(bytes: &[u8]) -> Result<AmdChain, ParseError> {
+pub fn build_chain(bytes: &[u8]) -> Result<AmdChain, ParseError> {
     let certs = X509::stack_from_pem(bytes)?;
 
     if certs.len() != 2 {

--- a/az-snp-vtpm/src/certs.rs
+++ b/az-snp-vtpm/src/certs.rs
@@ -77,7 +77,7 @@ pub struct AmdKds<'a>(&'a AttestationReport);
 #[derive(Error, Debug)]
 pub enum AmdKdsError {
     #[error("HTTP error")]
-    Http(#[from] ureq::Error),
+    Http(#[from] Box<ureq::Error>),
     #[error("io error")]
     Io(#[from] std::io::Error),
 }
@@ -88,7 +88,7 @@ impl<'a> AmdKds<'a> {
     }
 
     fn get(&self, url: &str) -> Result<Vec<u8>, AmdKdsError> {
-        let mut body = ureq::get(url).call()?.into_reader();
+        let mut body = ureq::get(url).call().map_err(Box::new)?.into_reader();
         let mut buffer = Vec::new();
         body.read_to_end(&mut buffer)?;
         Ok(buffer)

--- a/az-snp-vtpm/src/certs.rs
+++ b/az-snp-vtpm/src/certs.rs
@@ -1,17 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use crate::imds;
 use openssl::x509::X509;
-use reqwest::blocking::get as http_get;
-use reqwest::blocking::Client as http_client;
-use reqwest::StatusCode;
-use serde::Deserialize;
 use sev::firmware::guest::types::AttestationReport;
-use std::error::Error as StdError;
 use thiserror::Error;
 
 const KDS_CERT_SITE: &str = "https://kdsintf.amd.com";
-const IMDS_CERT_URL: &str = "http://169.254.169.254/metadata/THIM/amd/certification";
 const KDS_VCEK: &str = "/vcek/v1";
 const SEV_PROD_NAME: &str = "Milan";
 const KDS_CERT_CHAIN: &str = "cert_chain";
@@ -22,7 +17,7 @@ pub struct AmdChain {
 }
 
 #[derive(Error, Debug)]
-pub enum CertError {
+pub enum ValidateError {
     #[error("openssl error")]
     OpenSsl(#[from] openssl::error::ErrorStack),
     #[error("ARK is not self-signed")]
@@ -31,26 +26,32 @@ pub enum CertError {
     AskNotSignedByArk,
     #[error("VCEK is not signed by ASK")]
     VcekNotSignedByAsk,
-    #[error("AMD Cert Chain download failed with status code {0}")]
-    CertChainDownloadFailed(StatusCode),
-    #[error("VCEK download failed with status code {0}")]
-    VcekDownloadFailed(StatusCode),
-    #[error("HTTP error")]
-    Http(#[from] reqwest::Error),
+}
+
+#[derive(Error, Debug)]
+pub enum CertError {
+    #[error("openssl error")]
+    OpenSsl(#[from] openssl::error::ErrorStack),
+    #[error("AMD KDS error")]
+    AmdKdsError(#[from] AmdKdsError),
+    #[error("IMDS error")]
+    Imds(#[from] imds::ImdsError),
+    #[error("parsing error")]
+    Parse(#[from] ParseError),
 }
 
 impl AmdChain {
-    pub fn validate(&self) -> Result<(), CertError> {
+    pub fn validate(&self) -> Result<(), ValidateError> {
         let ark_pubkey = self.ark.public_key()?;
 
         let ark_signed = self.ark.verify(&ark_pubkey)?;
         if !ark_signed {
-            return Err(CertError::ArkNotSelfSigned);
+            return Err(ValidateError::ArkNotSelfSigned);
         }
 
         let ask_signed = self.ask.verify(&ark_pubkey)?;
         if !ask_signed {
-            return Err(CertError::AskNotSignedByArk);
+            return Err(ValidateError::AskNotSignedByArk);
         }
 
         Ok(())
@@ -60,33 +61,86 @@ impl AmdChain {
 pub struct Vcek(pub X509);
 
 impl Vcek {
-    pub fn validate(&self, amd_chain: &AmdChain) -> Result<(), CertError> {
+    pub fn validate(&self, amd_chain: &AmdChain) -> Result<(), ValidateError> {
         let ask_pubkey = amd_chain.ask.public_key()?;
         let vcek_signed = self.0.verify(&ask_pubkey)?;
         if !vcek_signed {
-            return Err(CertError::VcekNotSignedByAsk);
+            return Err(ValidateError::VcekNotSignedByAsk);
         }
 
         Ok(())
     }
 }
 
-pub fn get_chain_from_amd() -> Result<AmdChain, CertError> {
-    let url = format!("{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{KDS_CERT_CHAIN}");
-    let resp = http_get(url)?;
-    let status = resp.status();
-    if status != 200 {
-        return Err(CertError::CertChainDownloadFailed(status));
+pub struct AmdKds<'a>(&'a AttestationReport);
+
+#[derive(Error, Debug)]
+pub enum AmdKdsError {
+    #[error("HTTP error")]
+    Http(#[from] ureq::Error),
+    #[error("io error")]
+    Io(#[from] std::io::Error),
+}
+
+impl<'a> AmdKds<'a> {
+    pub fn new(report: &'a AttestationReport) -> Self {
+        Self(report)
     }
-    let bytes = resp.bytes()?;
-    let certs = X509::stack_from_pem(&bytes)?;
 
-    let ask = certs[0].clone();
-    let ark = certs[1].clone();
+    fn get(&self, url: &str) -> Result<Vec<u8>, AmdKdsError> {
+        let mut body = ureq::get(url).call()?.into_reader();
+        let mut buffer = Vec::new();
+        body.read_to_end(&mut buffer)?;
+        Ok(buffer)
+    }
+}
 
-    let chain = AmdChain { ask, ark };
+pub trait CertProvider {
+    fn get_chain(&self) -> Result<AmdChain, CertError>;
+    fn get_vcek(&self) -> Result<Vcek, CertError>;
+}
 
-    Ok(chain)
+impl CertProvider for imds::Response {
+    fn get_chain(&self) -> Result<AmdChain, CertError> {
+        let chain = build_chain(self.certificate_chain.as_bytes())?;
+        Ok(chain)
+    }
+
+    fn get_vcek(&self) -> Result<Vcek, CertError> {
+        let vcek = Vcek(X509::from_pem(self.vcek_cert.as_bytes())?);
+        Ok(vcek)
+    }
+}
+
+impl<'a> CertProvider for AmdKds<'a> {
+    fn get_chain(&self) -> Result<AmdChain, CertError> {
+        let url = format!("{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{KDS_CERT_CHAIN}");
+        let bytes = self.get(&url)?;
+
+        let certs = X509::stack_from_pem(&bytes)?;
+        let ask = certs[0].clone();
+        let ark = certs[1].clone();
+
+        let chain = AmdChain { ask, ark };
+
+        Ok(chain)
+    }
+
+    fn get_vcek(&self) -> Result<Vcek, CertError> {
+        let hw_id = hexify(&self.0.chip_id);
+        let url = format!(
+            "{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{hw_id}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
+            self.0.reported_tcb.boot_loader,
+            self.0.reported_tcb.tee,
+            self.0.reported_tcb.snp,
+            self.0.reported_tcb.microcode
+        );
+
+        let bytes = self.get(&url)?;
+        let cert = X509::from_der(&bytes)?;
+        let vcek = Vcek(cert);
+        Ok(vcek)
+    }
 }
 
 fn hexify(bytes: &[u8]) -> String {
@@ -97,60 +151,19 @@ fn hexify(bytes: &[u8]) -> String {
     hex_string
 }
 
-pub fn get_vcek_from_amd(report: &AttestationReport) -> Result<Vcek, CertError> {
-    let hw_id = hexify(&report.chip_id);
-    let url = format!(
-        "{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{hw_id}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
-        report.reported_tcb.boot_loader,
-        report.reported_tcb.tee,
-        report.reported_tcb.snp,
-        report.reported_tcb.microcode
-    );
-
-    let resp = http_get(url)?;
-    let status = resp.status();
-    if status != 200 {
-        return Err(CertError::VcekDownloadFailed(status));
-    }
-    let bytes = resp.bytes()?;
-    let cert = X509::from_der(&bytes)?;
-    Ok(Vcek(cert))
+#[derive(Error, Debug)]
+pub enum ParseError {
+    #[error("openssl error")]
+    OpenSsl(#[from] openssl::error::ErrorStack),
+    #[error("wrong amount of certificates (expected {0:?}, found {1:?})")]
+    WrongAmount(usize, usize),
 }
 
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct ImdsResponse {
-    vcek_cert: String,
-    certificate_chain: String,
-}
-
-pub fn get_from_imds() -> Result<(Vcek, AmdChain), Box<dyn StdError>> {
-    let client = http_client::new();
-    let resp = client
-        .get(IMDS_CERT_URL)
-        .header("Metadata", "true")
-        .send()?;
-
-    let status = resp.status();
-    if status != 200 {
-        let err_str = format!("Failed to get certificates from IMDS endpoint: HTTP {status}");
-        return Err(err_str.into());
-    }
-    let text = resp.text()?;
-    let res: ImdsResponse = serde_json::from_str(&text)?;
-
-    let vcek = Vcek(X509::from_pem(res.vcek_cert.as_bytes())?);
-    let cert_chain = build_chain(res.certificate_chain.as_bytes())?;
-
-    Ok((vcek, cert_chain))
-}
-
-fn build_chain(bytes: &[u8]) -> Result<AmdChain, Box<dyn StdError>> {
+fn build_chain(bytes: &[u8]) -> Result<AmdChain, ParseError> {
     let certs = X509::stack_from_pem(bytes)?;
 
     if certs.len() != 2 {
-        let err_str = format!("Expected 2 certificates in chain, got {}", certs.len());
-        return Err(err_str.into());
+        return Err(ParseError::WrongAmount(2, certs.len()));
     }
 
     let ask = certs[0].clone();

--- a/az-snp-vtpm/src/hcl.rs
+++ b/az-snp-vtpm/src/hcl.rs
@@ -157,7 +157,7 @@ pub fn verify_report_data(bytes: &[u8]) -> Result<(), ValidationError> {
     let report_data = &hcl_report.hw_report.report_data[..32];
 
     let mut hasher = Sha256::new();
-    hasher.update(&var_data);
+    hasher.update(var_data);
     let hash = hasher.finalize();
 
     if hash.as_slice() != report_data {

--- a/az-snp-vtpm/src/hcl.rs
+++ b/az-snp-vtpm/src/hcl.rs
@@ -2,10 +2,11 @@
 // Licensed under the MIT License.
 
 use memoffset::offset_of;
+#[cfg(feature = "verifier")]
 use openssl::pkey::{PKey, Public};
-use openssl::{self, sha::sha256};
 use serde::{Deserialize, Serialize};
 use sev::firmware::guest::types::AttestationReport;
+use sha2::{Digest, Sha256};
 use static_assertions::const_assert;
 use std::convert::TryFrom;
 use thiserror::Error;
@@ -133,6 +134,7 @@ impl TryFrom<&[u8]> for HclReportWithRuntimeData {
     }
 }
 
+#[cfg(feature = "verifier")]
 impl HclReportWithRuntimeData {
     pub fn get_attestation_key(&self) -> Result<PKey<Public>, openssl::error::ErrorStack> {
         let key = self.runtime_data.keys[0].key.as_ref();
@@ -153,8 +155,12 @@ pub enum ValidationError {
 pub fn verify_report_data(bytes: &[u8]) -> Result<(), ValidationError> {
     let (hcl_report, var_data) = buf_to_hcl_data(bytes)?;
     let report_data = &hcl_report.hw_report.report_data[..32];
-    let hash = sha256(var_data);
-    if hash != report_data {
+
+    let mut hasher = Sha256::new();
+    hasher.update(&var_data);
+    let hash = hasher.finalize();
+
+    if hash.as_slice() != report_data {
         return Err(ValidationError::ReportDataMismatchError);
     }
     Ok(())
@@ -170,6 +176,7 @@ mod tests {
         let res = verify_report_data(bytes);
         assert!(res.is_ok());
     }
+    #[cfg(feature = "verifier")]
     #[test]
     fn test_hcl_report() {
         let bytes: &[u8] = include_bytes!("../test/hcl-report.bin");

--- a/az-snp-vtpm/src/imds.rs
+++ b/az-snp-vtpm/src/imds.rs
@@ -13,7 +13,7 @@ pub struct Response {
 #[derive(Error, Debug)]
 pub enum ImdsError {
     #[error("HTTP error")]
-    Http(#[from] ureq::Error),
+    Http(#[from] Box<ureq::Error>),
     #[error("failed to read IMDS response")]
     Io(#[from] std::io::Error),
 }
@@ -21,7 +21,8 @@ pub enum ImdsError {
 pub fn retrieve_certs() -> Result<Response, ImdsError> {
     let response = ureq::get(IMDS_CERT_URL)
         .set("Metadata", "true")
-        .call()?
+        .call()
+        .map_err(Box::new)?
         .into_json()?;
     Ok(response)
 }

--- a/az-snp-vtpm/src/imds.rs
+++ b/az-snp-vtpm/src/imds.rs
@@ -1,0 +1,27 @@
+use serde::Deserialize;
+use thiserror::Error;
+
+const IMDS_CERT_URL: &str = "http://169.254.169.254/metadata/THIM/amd/certification";
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Response {
+    pub vcek_cert: String,
+    pub certificate_chain: String,
+}
+
+#[derive(Error, Debug)]
+pub enum ImdsError {
+    #[error("HTTP error")]
+    Http(#[from] ureq::Error),
+    #[error("failed to read IMDS response")]
+    Io(#[from] std::io::Error),
+}
+
+pub fn retrieve_certs() -> Result<Response, ImdsError> {
+    let response = ureq::get(IMDS_CERT_URL)
+        .set("Metadata", "true")
+        .call()?
+        .into_json()?;
+    Ok(response)
+}

--- a/az-snp-vtpm/src/imds.rs
+++ b/az-snp-vtpm/src/imds.rs
@@ -5,9 +5,9 @@ const IMDS_CERT_URL: &str = "http://169.254.169.254/metadata/THIM/amd/certificat
 
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Response {
-    pub vcek_cert: String,
-    pub certificate_chain: String,
+pub struct Certificates {
+    pub vcek_cert: Vec<u8>,
+    pub certificate_chain: Vec<u8>,
 }
 
 #[derive(Error, Debug)]
@@ -18,11 +18,11 @@ pub enum ImdsError {
     Io(#[from] std::io::Error),
 }
 
-pub fn retrieve_certs() -> Result<Response, ImdsError> {
-    let response = ureq::get(IMDS_CERT_URL)
+pub fn get_certs() -> Result<Certificates, ImdsError> {
+    let res: Certificates = ureq::get(IMDS_CERT_URL)
         .set("Metadata", "true")
         .call()
         .map_err(Box::new)?
         .into_json()?;
-    Ok(response)
+    Ok(res)
 }

--- a/az-snp-vtpm/src/imds.rs
+++ b/az-snp-vtpm/src/imds.rs
@@ -1,24 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::HttpError;
 use serde::Deserialize;
-use thiserror::Error;
 
 const IMDS_CERT_URL: &str = "http://169.254.169.254/metadata/THIM/amd/certification";
 
+/// PEM encoded VCEK certificate and AMD certificate chain.
 #[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct Certificates {
-    pub vcek_cert: Vec<u8>,
-    pub certificate_chain: Vec<u8>,
+    #[serde(rename = "vcekCert")]
+    pub vcek: String,
+    #[serde(rename = "certificateChain")]
+    pub amd_chain: String,
 }
 
-#[derive(Error, Debug)]
-pub enum ImdsError {
-    #[error("HTTP error")]
-    Http(#[from] Box<ureq::Error>),
-    #[error("failed to read IMDS response")]
-    Io(#[from] std::io::Error),
-}
-
-pub fn get_certs() -> Result<Certificates, ImdsError> {
+/// Get the VCEK certificate and the certificate chain from the Azure IMDS.
+/// **Note:** this can only be called from a Confidential VM.
+pub fn get_certs() -> Result<Certificates, HttpError> {
     let res: Certificates = ureq::get(IMDS_CERT_URL)
         .set("Metadata", "true")
         .call()

--- a/az-snp-vtpm/src/lib.rs
+++ b/az-snp-vtpm/src/lib.rs
@@ -21,7 +21,7 @@
 //!    let snp_report = hcl_report.snp_report();
 //!
 //!    let vcek = amd_kds::get_vcek(&snp_report)?;
-//!    let cert_chain = amd_kds::get_chain()?;
+//!    let cert_chain = amd_kds::get_cert_chain()?;
 //!
 //!    cert_chain.validate()?;
 //!    vcek.validate(&cert_chain)?;
@@ -32,6 +32,16 @@
 //!    Ok(())
 //!  }
 //!  ```
+
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum HttpError {
+    #[error("HTTP error")]
+    Http(#[from] Box<ureq::Error>),
+    #[error("failed to read HTTP response")]
+    Io(#[from] std::io::Error),
+}
 
 #[cfg(feature = "verifier")]
 pub mod amd_kds;

--- a/az-snp-vtpm/src/lib.rs
+++ b/az-snp-vtpm/src/lib.rs
@@ -7,31 +7,37 @@
 //!
 //!  The following code will retrieve an SNP report from the vTPM device, parse it, and validate it against the AMD certificate chain. Finally it will verify that a hash of a raw HCL report's [ReportData](hcl::ReportData) is equal to the `report_data` field in an embedded [Attestation Report](sev::firmware::guest::types::AttestationReport) structure.
 //!
+//!  #
 //!  ```no_run
-//!  use az_snp_vtpm::{certs, hcl, vtpm};
+//!  use az_snp_vtpm::vtpm::get_report;
+//!  use az_snp_vtpm::certs::{AmdKds, CertProvider};
 //!  use az_snp_vtpm::report::Validateable;
-//!  use az_snp_vtpm::hcl::HclReportWithRuntimeData;
+//!  use az_snp_vtpm::hcl::{verify_report_data, HclReportWithRuntimeData};
 //!  use std::error::Error;
 //!
 //!  fn main() -> Result<(), Box<dyn Error>> {
-//!    let bytes = vtpm::get_report()?;
+//!    let bytes = get_report()?;
 //!    let hcl_report: HclReportWithRuntimeData = bytes[..].try_into()?;
 //!    let snp_report = hcl_report.snp_report();
 //!
-//!    let vcek = certs::get_vcek_from_amd(snp_report)?;
-//!    let cert_chain = certs::get_chain_from_amd()?;
+//!    let amd_kds = AmdKds::new(&snp_report);
+//!    let vcek = amd_kds.get_vcek()?;
+//!    let cert_chain = amd_kds.get_chain()?;
 //!
 //!    cert_chain.validate()?;
 //!    vcek.validate(&cert_chain)?;
 //!    snp_report.validate(&vcek)?;
 //!
-//!    hcl::verify_report_data(&bytes)?;
+//!    verify_report_data(&bytes)?;
 //!
 //!    Ok(())
 //!  }
 //!  ```
 
+#[cfg(feature = "verifier")]
 pub mod certs;
 pub mod hcl;
+#[cfg(feature = "attester")]
+pub mod imds;
 pub mod report;
 pub mod vtpm;

--- a/az-snp-vtpm/src/lib.rs
+++ b/az-snp-vtpm/src/lib.rs
@@ -10,7 +10,7 @@
 //!  #
 //!  ```no_run
 //!  use az_snp_vtpm::vtpm::get_report;
-//!  use az_snp_vtpm::certs::{AmdKds, CertProvider};
+//!  use az_snp_vtpm::amd_kds;
 //!  use az_snp_vtpm::report::Validateable;
 //!  use az_snp_vtpm::hcl::{verify_report_data, HclReportWithRuntimeData};
 //!  use std::error::Error;
@@ -20,9 +20,8 @@
 //!    let hcl_report: HclReportWithRuntimeData = bytes[..].try_into()?;
 //!    let snp_report = hcl_report.snp_report();
 //!
-//!    let amd_kds = AmdKds::new(&snp_report);
-//!    let vcek = amd_kds.get_vcek()?;
-//!    let cert_chain = amd_kds.get_chain()?;
+//!    let vcek = amd_kds::get_vcek(&snp_report)?;
+//!    let cert_chain = amd_kds::get_chain()?;
 //!
 //!    cert_chain.validate()?;
 //!    vcek.validate(&cert_chain)?;
@@ -34,6 +33,8 @@
 //!  }
 //!  ```
 
+#[cfg(feature = "verifier")]
+pub mod amd_kds;
 #[cfg(feature = "verifier")]
 pub mod certs;
 pub mod hcl;

--- a/az-snp-vtpm/src/main.rs
+++ b/az-snp-vtpm/src/main.rs
@@ -52,13 +52,13 @@ fn main() -> Result<(), Box<dyn Error>> {
             let snp_report = hcl_report.snp_report();
 
             let (vcek, cert_chain) = if imds {
-                let certs = imds::get_certs()?;
-                let vcek = certs::Vcek(certs::X509::from_pem(&certs.vcek_cert)?);
-                let cert_chain = certs::build_chain(&certs.certificate_chain)?;
+                let pem_certs = imds::get_certs()?;
+                let vcek = certs::Vcek::from_pem(&pem_certs.vcek)?;
+                let cert_chain = certs::build_cert_chain(&pem_certs.amd_chain)?;
                 (vcek, cert_chain)
             } else {
                 let vcek = amd_kds::get_vcek(snp_report)?;
-                let cert_chain = amd_kds::get_chain()?;
+                let cert_chain = amd_kds::get_cert_chain()?;
                 (vcek, cert_chain)
             };
 

--- a/az-snp-vtpm/src/main.rs
+++ b/az-snp-vtpm/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let response = imds::retrieve_certs()?;
                 Box::new(response)
             } else {
-                let amd_kds = certs::AmdKds::new(&snp_report);
+                let amd_kds = certs::AmdKds::new(snp_report);
                 Box::new(amd_kds)
             };
 

--- a/az-snp-vtpm/src/report.rs
+++ b/az-snp-vtpm/src/report.rs
@@ -1,14 +1,19 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+#[cfg(feature = "verifier")]
 use super::certs::Vcek;
+#[cfg(feature = "verifier")]
 use openssl::{ecdsa::EcdsaSig, sha::Sha384};
-use sev::firmware::guest::types::{AttestationReport, Signature};
+use sev::firmware::guest::types::AttestationReport;
+#[cfg(feature = "verifier")]
+use sev::firmware::guest::types::Signature;
 use std::error::Error;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ValidateError {
+    #[cfg(feature = "verifier")]
     #[error("openssl error")]
     OpenSsl(#[from] openssl::error::ErrorStack),
     #[error("TCB data is not valid")]
@@ -21,10 +26,12 @@ pub enum ValidateError {
     Bincode(#[from] Box<bincode::ErrorKind>),
 }
 
+#[cfg(feature = "verifier")]
 pub trait Validateable {
     fn validate(&self, vcek: &Vcek) -> Result<(), ValidateError>;
 }
 
+#[cfg(feature = "verifier")]
 impl Validateable for AttestationReport {
     fn validate(&self, vcek: &Vcek) -> Result<(), ValidateError> {
         if !is_tcb_data_valid(self) {
@@ -51,10 +58,12 @@ pub fn parse(bytes: &[u8]) -> Result<AttestationReport, Box<dyn Error>> {
     Ok(decoded)
 }
 
+#[cfg(feature = "verifier")]
 fn is_tcb_data_valid(report: &AttestationReport) -> bool {
     report.reported_tcb == report.committed_tcb
 }
 
+#[cfg(feature = "verifier")]
 fn get_report_base(report: &AttestationReport) -> Result<Vec<u8>, Box<bincode::ErrorKind>> {
     let report_len = std::mem::size_of::<AttestationReport>();
     let signature_len = std::mem::size_of::<Signature>();

--- a/az-snp-vtpm/src/vtpm.rs
+++ b/az-snp-vtpm/src/vtpm.rs
@@ -74,9 +74,9 @@ pub fn get_ak_pub() -> Result<RsaPublicKey, AKPubError> {
     };
 
     let bytes = rsa_pk.modulus.as_unsigned_bytes_be();
-    let n = BigUint::from_bytes_be(&bytes);
+    let n = BigUint::from_bytes_be(bytes);
     let bytes = rsa_pk.public_exponent.as_unsigned_bytes_be();
-    let e = BigUint::from_bytes_be(&bytes);
+    let e = BigUint::from_bytes_be(bytes);
 
     let pkey = RsaPublicKey::new(n, e)?;
     Ok(pkey)


### PR DESCRIPTION
# Add feature flags for attester/verifier code

fixes #9

To allow compilation for small attester bins we can split off the verifier code, which has a reliance on OpenSSL.

- Code has been moved around a bit to make the split easier
- Added Cargo --feature toggles
- Switch to rsa crate for attester feature
- Switch to ureq for http (reqwest is too heavy for imds calls and requires the unused tokio async ecosystem as a dependency)

## How to use

When using the library:

```toml
az-snp-vtpm = { path = "../", default-features = false, features = ["attester"] }
````

## Testing done

Created a test binary using only the "attester" feature and ran it on a fresh RHEL CVM:

```rust
use az_snp_vtpm::hcl::HclReportWithRuntimeData;
use az_snp_vtpm::imds;
use az_snp_vtpm::vtpm;
use std::error::Error;

fn main() -> Result<(), Box<dyn Error>> {
    let bytes = vtpm::get_report()?;
    let hcl_report: HclReportWithRuntimeData = bytes[..].try_into()?;
    let snp_report = hcl_report.snp_report();
    let certs = imds::retrieve_certs()?;
    let vcek = certs.vcek_cert;
    println!("vcek: {}", vcek);
    println!("snp_report: {}", snp_report);
    Ok(())
}
```