### PR TITLE
Expose HCL data struct

### DIFF
--- a/az-snp-vtpm/Cargo.toml
+++ b/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-snp-vtpm/Makefile
+++ b/az-snp-vtpm/Makefile
@@ -4,7 +4,7 @@ VNET_ID ?= /subscriptions/<sub id>/resourceGroups/<vnet rg>/providers/Microsoft.
 IMAGE_ID ?= -
 SUBNET_NAME ?= default
 SSH_PUB_KEY_PATH ?= ~/.ssh/id_rsa.pub
-ADMIN_PULIC_KEY = $(shell cat $(SSH_PUB_KEY_PATH))
+ADMIN_PUBLIC_KEY = $(shell cat $(SSH_PUB_KEY_PATH))
 ifeq ($(SUFFIX),)
 	SUFFIX := $(shell bash -c 'echo $$RANDOM | md5sum | head -c 6')
 endif
@@ -22,7 +22,7 @@ deploy:
 		--parameters subnetName=$(SUBNET_NAME) \
 		--parameters vnetId=$(VNET_ID) \
 		$(if $(IMAGE_ID:-=),--parameters imageId=$(IMAGE_ID)) \
-		--parameters adminPublicKey='$(ADMIN_PULIC_KEY)' \
+		--parameters adminPublicKey='$(ADMIN_PUBLIC_KEY)' \
 		--parameters assignPublicIP=$(ASSIGN_PUBLIC_IP) && \
 	echo -n "$(VM_NAME): " && \
 	az network nic show \

--- a/az-snp-vtpm/src/lib.rs
+++ b/az-snp-vtpm/src/lib.rs
@@ -5,20 +5,20 @@
 //!
 //!  # SNP Report Validation
 //!
-//!  The following code will retrieve an SNP report from the vTPM device, parse it, and validate it against the AMD certificate chain. Finally it will verify that a hash of a raw HCL report's [ReportData](hcl::ReportData) is equal to the `report_data` field in an embedded [Attestation Report](sev::firmware::guest::types::AttestationReport) structure.
+//!  The following code will retrieve an SNP report from the vTPM device, parse it, and validate it against the AMD certificate chain. Finally it will verify that a hash of a raw HCL report's [RuntimeData](hcl::RuntimeData) is equal to the `report_data` field in an embedded [Attestation Report](sev::firmware::guest::types::AttestationReport) structure.
 //!
 //!  #
 //!  ```no_run
 //!  use az_snp_vtpm::vtpm::get_report;
 //!  use az_snp_vtpm::amd_kds;
 //!  use az_snp_vtpm::report::Validateable;
-//!  use az_snp_vtpm::hcl::{verify_report_data, HclReportWithRuntimeData};
+//!  use az_snp_vtpm::hcl::{self, HclData};
 //!  use std::error::Error;
 //!
 //!  fn main() -> Result<(), Box<dyn Error>> {
 //!    let bytes = get_report()?;
-//!    let hcl_report: HclReportWithRuntimeData = bytes[..].try_into()?;
-//!    let snp_report = hcl_report.snp_report();
+//!    let hcl_data: HclData = bytes[..].try_into()?;
+//!    let snp_report = hcl_data.report().snp_report();
 //!
 //!    let vcek = amd_kds::get_vcek(&snp_report)?;
 //!    let cert_chain = amd_kds::get_cert_chain()?;
@@ -27,7 +27,8 @@
 //!    vcek.validate(&cert_chain)?;
 //!    snp_report.validate(&vcek)?;
 //!
-//!    verify_report_data(&bytes)?;
+//!    let var_data = hcl_data.var_data();
+//!    hcl_data.report().verify_report_data(&var_data)?;
 //!
 //!    Ok(())
 //!  }

--- a/az-snp-vtpm/src/main.rs
+++ b/az-snp-vtpm/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use az_snp_vtpm::hcl::HclReportWithRuntimeData;
+use az_snp_vtpm::hcl::HclData;
 use az_snp_vtpm::{amd_kds, certs, imds, report, vtpm};
 use clap::Parser;
 use report::Validateable;
@@ -48,8 +48,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 Some(file_name) => read_file(&file_name)?,
                 None => vtpm::get_report()?,
             };
-            let hcl_report: HclReportWithRuntimeData = bytes[..].try_into()?;
-            let snp_report = hcl_report.snp_report();
+            let hcl_data: HclData = bytes.as_slice().try_into()?;
+            let snp_report = hcl_data.report().snp_report();
 
             let (vcek, cert_chain) = if imds {
                 let pem_certs = imds::get_certs()?;


### PR DESCRIPTION
# Expose HCL data struct

fixes #15

- Replaced `HclReportWithRuntimeData` with a `HclData` struct that wraps around a parsed HCL Report and unparsed JSON Runtime Data (VarData), which we require for hash computation in verification.
- Move VerifyReportData (the above hash) to the `HclAttestationReport`
- Bail out if the Hashing algo isn't specified as sha256 in the IGVM field (we don't know how to handle other hashes in report data, if they exist).
- Bumped crate version, since the API changed.
- Switch the ak_pub type to openssl, since that's what we use on the verifier.
- Made the nonce param mandatory, since there is no use case for omitting it.

## How to use

n/a

## Testing done

Tested attestation/verification on a RHEL cvm.
