### PR TITLE
Remove vTPM device check

### DIFF
--- a/az-snp-vtpm/src/vtpm.rs
+++ b/az-snp-vtpm/src/vtpm.rs
@@ -38,11 +38,6 @@ const VTPM_QUOTE_PCR_SLOTS: [PcrSlot; 9] = [
     PcrSlot::Slot14,
 ];
 
-pub fn has_tpm_device() -> bool {
-    let conf: TctiNameConf = TctiNameConf::Device(DeviceConfig::default());
-    Context::new(conf).is_ok()
-}
-
 pub fn get_report() -> Result<Vec<u8>, tss_esapi::Error> {
     use tss_esapi::handles::NvIndexTpmHandle;
     let nv_index = NvIndexTpmHandle::new(VTPM_HCL_REPORT_NV_INDEX)?;


### PR DESCRIPTION
# Remove platform detection heuristic

fixes #4 

vTPM availability as platform detection heuristic will yield false positives, as other TEE platforms will also have a device.

## How to use

n/a

## Testing done

n/a
