### PR TITLE
Fix feature compilation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,14 @@ jobs:
       run: cargo build --verbose --all
       working-directory: az-snp-vtpm
 
+    - name: Check verifier-only
+      run: cargo check --verbose --no-default-features features=verifier
+      working-directory: az-snp-vtpm
+
+    - name: Check attester-only
+      run: cargo check --verbose --no-default-features features=attester
+      working-directory: az-snp-vtpm
+
     - name: Run tests
       run: cargo test --verbose --all
       working-directory: az-snp-vtpm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,11 +37,11 @@ jobs:
       working-directory: az-snp-vtpm
 
     - name: Check verifier-only
-      run: cargo check --verbose --no-default-features features=verifier
+      run: cargo check --verbose --no-default-features --features=verifier
       working-directory: az-snp-vtpm
 
     - name: Check attester-only
-      run: cargo check --verbose --no-default-features features=attester
+      run: cargo check --verbose --no-default-features --features=attester
       working-directory: az-snp-vtpm
 
     - name: Run tests

--- a/az-snp-vtpm/Cargo.toml
+++ b/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-snp-vtpm/src/hcl.rs
+++ b/az-snp-vtpm/src/hcl.rs
@@ -151,6 +151,7 @@ impl TryFrom<&[u8]> for HclData {
 pub enum ParseError {
     #[error("json parse error")]
     Report(#[from] serde_json::Error),
+    #[cfg(feature = "verifier")]
     #[error("openssl error")]
     OpenSSL(#[from] openssl::error::ErrorStack),
 }

--- a/az-snp-vtpm/src/vtpm.rs
+++ b/az-snp-vtpm/src/vtpm.rs
@@ -18,10 +18,14 @@ use tss_esapi::interface_types::resource_handles::NvAuth;
 use tss_esapi::interface_types::session_handles::AuthSession;
 use tss_esapi::structures::pcr_selection_list::PcrSelectionListBuilder;
 use tss_esapi::structures::pcr_slot::PcrSlot;
+#[cfg(feature = "verifier")]
+use tss_esapi::structures::Attest;
 use tss_esapi::structures::SignatureScheme;
-use tss_esapi::structures::{Attest, AttestInfo, Data, Signature};
+use tss_esapi::structures::{AttestInfo, Data, Signature};
 use tss_esapi::tcti_ldr::{DeviceConfig, TctiNameConf};
-use tss_esapi::traits::{Marshall, UnMarshall};
+use tss_esapi::traits::Marshall;
+#[cfg(feature = "verifier")]
+use tss_esapi::traits::UnMarshall;
 use tss_esapi::Context;
 
 const VTPM_HCL_REPORT_NV_INDEX: u32 = 0x01400001;
@@ -134,6 +138,7 @@ pub fn get_quote(data: &[u8]) -> Result<Quote, QuoteError> {
     Ok(Quote { signature, message })
 }
 
+#[cfg(feature = "verifier")]
 #[derive(Error, Debug)]
 pub enum VerifyError {
     #[error("tss error")]


### PR DESCRIPTION
# Fix feature compilation

fixes #20 

- Put openssl types behind verifier feature annotations.
- Added tests.

## How to use

n/a

## Testing done

Build locally w/ `--no-default-features --features {attester,verifier}`
