### PR TITLE
Pin sev crate to use 1.1.0, due to 1.2.0 breaking changes

### DIFF
--- a/az-snp-vtpm/Cargo.toml
+++ b/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-snp-vtpm/src/amd_kds.rs
+++ b/az-snp-vtpm/src/amd_kds.rs
@@ -4,7 +4,7 @@
 use crate::certs::{AmdChain, Vcek};
 use crate::HttpError;
 use openssl::x509::X509;
-use sev::firmware::guest::types::AttestationReport;
+use sev::firmware::guest::AttestationReport;
 use thiserror::Error;
 
 const KDS_CERT_SITE: &str = "https://kdsintf.amd.com";
@@ -54,7 +54,7 @@ pub fn get_vcek(report: &AttestationReport) -> Result<Vcek, AmdKdsError> {
     let hw_id = hexify(&report.chip_id);
     let url = format!(
         "{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{hw_id}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
-        report.reported_tcb.boot_loader,
+        report.reported_tcb.bootloader,
         report.reported_tcb.tee,
         report.reported_tcb.snp,
         report.reported_tcb.microcode

--- a/az-snp-vtpm/src/hcl.rs
+++ b/az-snp-vtpm/src/hcl.rs
@@ -5,7 +5,7 @@ use memoffset::offset_of;
 #[cfg(feature = "verifier")]
 use openssl::pkey::{PKey, Public};
 use serde::{Deserialize, Serialize};
-use sev::firmware::guest::types::AttestationReport;
+use sev::firmware::guest::AttestationReport;
 use sha2::{Digest, Sha256};
 use static_assertions::const_assert;
 use std::convert::TryFrom;

--- a/az-snp-vtpm/src/report.rs
+++ b/az-snp-vtpm/src/report.rs
@@ -5,9 +5,9 @@
 use super::certs::Vcek;
 #[cfg(feature = "verifier")]
 use openssl::{ecdsa::EcdsaSig, sha::Sha384};
-use sev::firmware::guest::types::AttestationReport;
 #[cfg(feature = "verifier")]
-use sev::firmware::guest::types::Signature;
+use sev::certs::snp::ecdsa::Signature;
+use sev::firmware::guest::AttestationReport;
 use std::error::Error;
 use thiserror::Error;
 


### PR DESCRIPTION
# Pin sev crate to use 1.1.0, due to 1.2.0 breaking changes

sev 1.2.0 introduced a couple of breaking changes. fixes https://github.com/confidential-containers/kbs/issues/102

## How to use

n/a

## Testing done

```bash
cargo t
```
