### PR TITLE
Bump sev dependency to 1.2.0

### DIFF
--- a/az-snp-vtpm/Cargo.toml
+++ b/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -25,7 +25,7 @@ openssl = { version = "0.10.45", features = ["vendored"], optional = true }
 rsa = { version = "0.8.2", features = ["pkcs5", "sha2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sev = "1"
+sev = "1.2.0"
 sha2 = "0.10.6"
 static_assertions = "^1.1.0"
 thiserror = "1.0.38"


### PR DESCRIPTION
# Bump sev dependency to 1.2.0

During testing with several kbs-related repos. I found a combination which produce a broken build. If a repo already specifies an `sev` dependency at `1.1` and this crate is fine with any 1 it will pick the existing 1.1 dep (and hence the compilation fails)

## How to use

n/a

## Testing done

Build attestation agent with this rev as a dependency, it fails now as expected at module resolution:

```
error: failed to select a version for `sev`.
    ... required by package `az-snp-vtpm v0.2.3 (https://github.com/mkulke/azure-cvm-tooling.git?rev=f5964af#f5964afd)`
    ... which satisfies git dependency `az-snp-vtpm` of package `attestation-service v0.1.0 (/home/magnuskulke/tmp/attestation-service/attestation-service)`
    ... which satisfies path dependency `attestation-service` (locked to 0.1.0) of package `grpc-as v0.1.0 (/home/magnuskulke/tmp/attestation-service/bin/grpc-as)`
versions that meet the requirements `^1.2.0` are: 1.2.0

all possible versions conflict with previously selected packages.

  previously selected package `sev v1.1.0`
    ... which satisfies dependency `sev = "=1.1.0"` (locked to 1.1.0) of package `attestation-service v0.1.0 (/home/magnuskulke/tmp/attestation-service/attestation-service)`
    ... which satisfies path dependency `attestation-service` (locked to 0.1.0) of package `grpc-as v0.1.0 (/home/magnuskulke/tmp/attestation-service/bin/grpc-as)`

failed to select a version for `sev` which could resolve this conflict
```
