### PR TITLE
Revert sev crate update

### DIFF
--- a/az-snp-vtpm/Cargo.toml
+++ b/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.2.3"
+version = "0.2.2"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -25,7 +25,7 @@ openssl = { version = "0.10.45", features = ["vendored"], optional = true }
 rsa = { version = "0.8.2", features = ["pkcs5", "sha2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sev = "1.2.0"
+sev = "1"
 sha2 = "0.10.6"
 static_assertions = "^1.1.0"
 thiserror = "1.0.38"

--- a/az-snp-vtpm/Cargo.toml
+++ b/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.2.1"
+version = "0.2.3"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-snp-vtpm/Cargo.toml
+++ b/az-snp-vtpm/Cargo.toml
@@ -25,7 +25,7 @@ openssl = { version = "0.10.45", features = ["vendored"], optional = true }
 rsa = { version = "0.8.2", features = ["pkcs5", "sha2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sev = "1"
+sev = "=1.1.0"
 sha2 = "0.10.6"
 static_assertions = "^1.1.0"
 thiserror = "1.0.38"

--- a/az-snp-vtpm/Cargo.toml
+++ b/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.2.2"
+version = "0.2.1"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-snp-vtpm/src/amd_kds.rs
+++ b/az-snp-vtpm/src/amd_kds.rs
@@ -4,7 +4,7 @@
 use crate::certs::{AmdChain, Vcek};
 use crate::HttpError;
 use openssl::x509::X509;
-use sev::firmware::guest::AttestationReport;
+use sev::firmware::guest::types::AttestationReport;
 use thiserror::Error;
 
 const KDS_CERT_SITE: &str = "https://kdsintf.amd.com";
@@ -54,7 +54,7 @@ pub fn get_vcek(report: &AttestationReport) -> Result<Vcek, AmdKdsError> {
     let hw_id = hexify(&report.chip_id);
     let url = format!(
         "{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{hw_id}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
-        report.reported_tcb.bootloader,
+        report.reported_tcb.boot_loader,
         report.reported_tcb.tee,
         report.reported_tcb.snp,
         report.reported_tcb.microcode

--- a/az-snp-vtpm/src/hcl.rs
+++ b/az-snp-vtpm/src/hcl.rs
@@ -5,7 +5,7 @@ use memoffset::offset_of;
 #[cfg(feature = "verifier")]
 use openssl::pkey::{PKey, Public};
 use serde::{Deserialize, Serialize};
-use sev::firmware::guest::AttestationReport;
+use sev::firmware::guest::types::AttestationReport;
 use sha2::{Digest, Sha256};
 use static_assertions::const_assert;
 use std::convert::TryFrom;

--- a/az-snp-vtpm/src/report.rs
+++ b/az-snp-vtpm/src/report.rs
@@ -5,9 +5,9 @@
 use super::certs::Vcek;
 #[cfg(feature = "verifier")]
 use openssl::{ecdsa::EcdsaSig, sha::Sha384};
+use sev::firmware::guest::types::AttestationReport;
 #[cfg(feature = "verifier")]
-use sev::certs::snp::ecdsa::Signature;
-use sev::firmware::guest::AttestationReport;
+use sev::firmware::guest::types::Signature;
 use std::error::Error;
 use thiserror::Error;
 


### PR DESCRIPTION
# Revert sev crate update

Since coco/attestation-service has pinned the crate to "1.1.0" we keep running into build problems in KBS projects. We can shelf the 1.2.0 adjustments for the time being, until the coco projects updates to a more recent version of the sev crate.

## How to use

n/a

## Testing done

Successfully built `kbs` with bundled `attestion-service`, dependency pointing to a fork that uses this branch.