### PR TITLE
un-vendor openssl

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y build-essential libtss2-dev pkg-config
+        sudo apt-get install -y build-essential libssl-dev pkg-config libtss2-dev
 
     - name: Build example project
       working-directory: ./az-snp-vtpm

--- a/az-snp-vtpm/Cargo.toml
+++ b/az-snp-vtpm/Cargo.toml
@@ -21,7 +21,7 @@ bincode = "1"
 clap = { version = "4", features = ["derive"] }
 jsonwebkey = { version = "0.3.5", features = ["pkcs-convert"] }
 memoffset = "0.8.0"
-openssl = { version = "0.10.45", features = ["vendored"], optional = true }
+openssl = { version = "0.10", optional = true }
 rsa = { version = "0.8.2", features = ["pkcs5", "sha2"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
# Un-vendor openssl

Since we split verifier and attester features, and only the former requires openssl, we should not vendor the dependency any more. It will [cause problems](https://cloud-native.slack.com/archives/C039JSH0807/p1687960842469079) when interfering with libraries that dynamically link to openssl.

## How to use

n/a

## Testing done

Compiled a kbs with an attestation-service fork using this az-snp-vtpm branch as a dependency. Performed a key release, using a tdx attester/verifier (tdx libraries dynamically link to openssl). There were segfaults due to conflicting openssl library calls.