### PR TITLE
Include all PCRs into quote

### DIFF
--- a/az-snp-vtpm/src/vtpm.rs
+++ b/az-snp-vtpm/src/vtpm.rs
@@ -30,7 +30,7 @@ use tss_esapi::Context;
 
 const VTPM_HCL_REPORT_NV_INDEX: u32 = 0x01400001;
 const VTPM_AK_HANDLE: u32 = 0x81000003;
-const VTPM_QUOTE_PCR_SLOTS: [PcrSlot; 9] = [
+const VTPM_QUOTE_PCR_SLOTS: [PcrSlot; 24] = [
     PcrSlot::Slot0,
     PcrSlot::Slot1,
     PcrSlot::Slot2,
@@ -39,7 +39,22 @@ const VTPM_QUOTE_PCR_SLOTS: [PcrSlot; 9] = [
     PcrSlot::Slot5,
     PcrSlot::Slot6,
     PcrSlot::Slot7,
+    PcrSlot::Slot8,
+    PcrSlot::Slot9,
+    PcrSlot::Slot10,
+    PcrSlot::Slot11,
+    PcrSlot::Slot12,
+    PcrSlot::Slot13,
     PcrSlot::Slot14,
+    PcrSlot::Slot15,
+    PcrSlot::Slot16,
+    PcrSlot::Slot17,
+    PcrSlot::Slot18,
+    PcrSlot::Slot19,
+    PcrSlot::Slot20,
+    PcrSlot::Slot21,
+    PcrSlot::Slot22,
+    PcrSlot::Slot23,
 ];
 
 pub fn get_report() -> Result<Vec<u8>, tss_esapi::Error> {


### PR DESCRIPTION
# Include all PCRs into quote

Including all vTPM PCRs in the quote so the decision on which PCRs should be validated can be done by the verifier's appraisal policy.

## How to use

This change should be compatible with other existing components and won't break things upstream. The reference value verification isn't yet implemented in the KBS.

## Testing done

Checked an AA with this change can still issue a valid quote that now contains additional PCRs.
