### PR TITLE
Add az-report-ready project

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,7 +1,7 @@
 name: e2e
 
 on:
-  pull_request:
+  push:
     branches: [ "main" ]
 
 jobs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,8 +10,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  az-snp-vtpm:
     runs-on: ubuntu-latest
 
     steps:
@@ -55,3 +54,37 @@ jobs:
     - name: Lint
       run: cargo clippy --all-targets --all-features --all -- -D warnings
       working-directory: az-snp-vtpm
+
+  az-report-ready:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Install additional components
+      shell: bash
+      run: |
+        rustup component add rustfmt
+        rustup component add clippy
+
+    - name: Build
+      run: cargo build --verbose --all
+      working-directory: az-report-ready
+
+    - name: Run tests
+      run: cargo test --verbose --all
+      working-directory: az-report-ready
+
+    - name: Format
+      run: cargo fmt --all -- --check
+      working-directory: az-report-ready
+
+    - name: Lint
+      run: cargo clippy --all-targets --all-features --all -- -D warnings
+      working-directory: az-report-ready

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,10 @@
 
 Assorted tools and libraries to use with [Azure CVMs](https://azure.microsoft.com/en-us/solutions/confidential-compute/).
 
-# vTPM-SNP
+# az-snp-vtpm
 
 Library and CLI to integrate with vTPM on SEV-SNP enabled machines.
+
+# az-report-read
+
+CLI to registers Azure VMs as ready without relying on an agent.

--- a/az-report-ready/.gitignore
+++ b/az-report-ready/.gitignore
@@ -1,0 +1,2 @@
+target
+Cargo.lock

--- a/az-report-ready/Cargo.toml
+++ b/az-report-ready/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "az-report-ready"
+version = "0.1.0"
+edition = "2021"
+repository = "https://github.com/kinvolk/azure-cvm-tooling/"
+license = "MIT"
+keywords = ["azure", "goalstate"]
+categories = ["virtualization"]
+description = "Register Azure VMs as ready"
+
+[dependencies]
+anyhow = "1.0.75"
+clap = { version = "4.4.6", features = ["derive"] }
+log = "0.4.20"
+quick-xml = { version = "0.30.0", features = ["encoding", "serialize", "serde-types"] }
+serde = { version = "1", features = ["derive"] }
+ureq = { version = "2.8.0", default-features = false, features = ["serde"] }

--- a/az-report-ready/README.md
+++ b/az-report-ready/README.md
@@ -1,0 +1,29 @@
+# az-report-ready
+
+The program implements a [ceremony](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/no-agent) required on Azure VMs that do not run walinuxagent or a cloud-init service. The VM needs to report itself as ready otherwise a reboot will be triggered.
+
+## Build
+
+```bash
+cargo b --release
+```
+
+Statically w/ musl:
+
+```bash
+cargo b --release --target x86_64-unknown-linux-musl
+```
+
+Statically w/ glibc:
+
+```bash
+RUSTFLAGS='-C target-feature=+crt-static' cargo b --release --target x86_64-unknown-linux-gnu
+```
+
+## Run
+
+The tool is supposed to run on an Azure VM.
+
+```
+cargo r --release -- -h
+```

--- a/az-report-ready/src/main.rs
+++ b/az-report-ready/src/main.rs
@@ -1,0 +1,185 @@
+use anyhow::{anyhow, Result};
+use clap::Parser;
+use log::{info, warn};
+use quick_xml::de::from_str;
+use quick_xml::se::to_string;
+use serde::{Deserialize, Serialize};
+use std::convert::From;
+use std::thread;
+use std::time::Duration;
+
+const WIRESERVER_ENDPOINT: &str = "http://168.63.129.16/machine";
+const RETRY_DELAY: Duration = Duration::from_secs(2);
+
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// WireServer endpoint (you should not need to change this)
+    #[arg(short, long, default_value = WIRESERVER_ENDPOINT)]
+    wireserver_endpoint: String,
+    /// Number of retries
+    #[arg(short, long, default_value = "3")]
+    retries: u32,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct InnerHealth {
+    state: String,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct Role {
+    instance_id: String,
+    health: InnerHealth,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct RoleInstance {
+    instance_id: String,
+}
+
+trait RoleContainer {}
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct Container<T: RoleContainer> {
+    container_id: String,
+    role_instance_list: T,
+}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct RoleList {
+    role: Vec<Role>,
+}
+impl RoleContainer for RoleList {}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct RoleInstanceList {
+    role_instance: Vec<RoleInstance>,
+}
+impl RoleContainer for RoleInstanceList {}
+
+#[derive(Deserialize, Serialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct Health {
+    goal_state_incarnation: u32,
+    container: Container<RoleList>,
+}
+
+impl Health {
+    fn new(info: &InstanceInfo) -> Self {
+        let role = Role {
+            instance_id: info.instance_id.clone(),
+            health: InnerHealth {
+                state: "Ready".into(),
+            },
+        };
+        let role_instance_list = RoleList { role: vec![role] };
+        Health {
+            goal_state_incarnation: info.incarnation,
+            container: Container {
+                container_id: info.container_id.clone(),
+                role_instance_list,
+            },
+        }
+    }
+}
+
+#[derive(Deserialize, Debug)]
+#[serde(rename_all = "PascalCase")]
+struct GoalState {
+    container: Container<RoleInstanceList>,
+    incarnation: u32,
+}
+
+struct InstanceInfo {
+    instance_id: String,
+    container_id: String,
+    incarnation: u32,
+}
+
+impl From<GoalState> for InstanceInfo {
+    fn from(gs: GoalState) -> Self {
+        let container_id = gs.container.container_id;
+        let instance_id = gs.container.role_instance_list.role_instance[0]
+            .instance_id
+            .clone();
+        let incarnation = gs.incarnation;
+        InstanceInfo {
+            instance_id,
+            container_id,
+            incarnation,
+        }
+    }
+}
+
+fn get_goalstate(endpoint: &str) -> Result<GoalState> {
+    let body = ureq::get(endpoint)
+        .query("comp", "goalstate")
+        .set("x-ms-version", "2012-11-30")
+        .call()?
+        .into_string()?;
+    let goal_state: GoalState = from_str(&body)?;
+    Ok(goal_state)
+}
+
+fn post_health(endpoint: &str, health: &Health) -> Result<()> {
+    let body = to_string(health)?;
+    ureq::post(endpoint)
+        .query("comp", "health")
+        .set("content-type", "text/xml;charset=utf-8")
+        .set("x-ms-version", "2012-11-30")
+        .set("x-ms-agent-name", "custom-provisioning")
+        .send_string(&body)?;
+    Ok(())
+}
+
+fn register(wireserver_endpoint: &str) -> Result<()> {
+    let goal_state = get_goalstate(wireserver_endpoint)?;
+    let info: InstanceInfo = goal_state.into();
+    let health = Health::new(&info);
+    post_health(wireserver_endpoint, &health)?;
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    for _ in 0..args.retries {
+        if register(&args.wireserver_endpoint).is_ok() {
+            info!("Successfully reported health");
+            return Ok(());
+        }
+        warn!("Failed to report health, retrying...");
+        thread::sleep(RETRY_DELAY);
+    }
+
+    Err(anyhow!("Failed to report health"))
+}
+
+#[test]
+fn parse_goalstate() {
+    let goal_state_str = r#"
+        <?xml version="1.0" encoding="utf-8"?>
+        <GoalState>
+            <Incarnation>1</Incarnation>
+            <Container>
+                <ContainerId>123</ContainerId>
+                <RoleInstanceList>
+                    <RoleInstance>
+                        <InstanceId>456</InstanceId>
+                    </RoleInstance>
+                </RoleInstanceList>
+            </Container>
+        </GoalState>
+    "#;
+
+    let goal_state: GoalState = from_str(goal_state_str).unwrap();
+    let info: InstanceInfo = goal_state.into();
+    assert_eq!(info.container_id, "123");
+    assert_eq!(info.instance_id, "456");
+    assert_eq!(info.incarnation, 1);
+}

--- a/az-report-ready/systemd/az-report-ready.service
+++ b/az-report-ready/systemd/az-report-ready.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Report VM as ready
-After=network.target
-DefaultDependencies=no
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot

--- a/az-report-ready/systemd/az-report-ready.service
+++ b/az-report-ready/systemd/az-report-ready.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Report VM as ready
+After=network.target
+DefaultDependencies=no
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/az-report-ready
+ExecStartPost=/usr/bin/systemctl disable az-report-ready.service
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Add az-report-ready project

The tool is required to create (C)VMs without relying on an agent to report it's readyness to Azure. It's an implementation of the steps outlined in the [docs](https://learn.microsoft.com/en-us/azure/virtual-machines/linux/no-agent).

The tool is supposed to run in early boot, possibly initial ramdisks or otherwise restricted envs in which we cannot assume the presence of curl and other bash scripting facilities, hence the single binary program.

## How to use

The tool supposed to run once at startup of a VM as soon as the network stack is available. It'll report a success launch to Azure and the create-vm API will yield success.

You can use this image to test an agent-less launch: (access/debug the vm via serial console): `/CommunityGalleries/cococommunity-42d8482d-92cd-415b-b332-7648bd978eff/images/peerpod-podvm-experimental/versions/20231009.0.2`

## Testing done

Started ~30 of VMs to verify the tool is reliable and the defaults are sensible.
