### PR TITLE
Add cargo audit workflow

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,24 @@
+name: Security audit
+on:
+  workflow_dispatch:
+  schedule:
+  - cron: '0 0 * * *'
+  push:
+    paths: 
+    - '**/Cargo.toml'
+    - '**/Cargo.lock'
+
+jobs:
+  az-cvm-vtpm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # https://github.com/actions/checkout/issues/1430
+      - name: Move az-cvm-vtpm/* to root
+        run: mv az-cvm-vtpm/* .
+
+      - uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Add cargo audit workflow

Added a cargo audit workflow that runs on schedule, manually triggered and on pushes to Cargo.*

fixes #31

## How to use

n/a

## Testing done

Ran an audit workflow ([with findings](https://github.com/mkulke/azure-cvm-tooling/actions/runs/7207404690/job/19634197684))
