### PR TITLE
vtpm: add method to get sha256 PCRs from Quote

### DIFF
--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-cvm-vtpm"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 required-features = ["attester", "verifier"]
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.5.1" }
+az-cvm-vtpm = { path = "..", version = "0.5.2" }
 bincode.workspace = true
 clap.workspace = true
 openssl = { workspace = true, optional = true }

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-tdx-vtpm"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "tdx-vtpm"
 path = "src/main.rs"
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.5.1" }
+az-cvm-vtpm = { path = "..", version = "0.5.2" }
 base64-url = "2.0.0"
 bincode.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Added a method to retrieve the PCR values from a quote. 

Internally the PCRs are still represented as `Vec<Vec<u8>>`, due to serialization concerns of large arrays. For the consumer a fixed byte array `Vec<[u8; 32]>` is more convenient, so they don't have to perform runtime assertions on the vector size.

## How to use

Call `quote.pcrs_sha256()`

## Testing done

A test has been added to make sure the transformation is non-destructive.

Ran `cargo semver-checks` to make sure there is no breaking api change.
