### PR TITLE
bump: sev crate to 3.1.1

### DIFF
--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-cvm-vtpm"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 required-features = ["attester", "verifier"]
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.5.2" }
+az-cvm-vtpm = { path = "..", version = "0.5.3" }
 bincode.workspace = true
 clap.workspace = true
 openssl = { workspace = true, optional = true }

--- a/az-cvm-vtpm/az-snp-vtpm/example/src/main.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/example/src/main.rs
@@ -68,7 +68,7 @@ impl RelyingParty {
     pub fn request_secret(&mut self) -> Vec<u8> {
         // placeholder for a real nonce, it is usually randomly generated ephemeral value.
         let nonce = "challenge".as_bytes().to_vec();
-        self.nonce = nonce.clone();
+        self.nonce.clone_from(&nonce);
         nonce
     }
 

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-tdx-vtpm"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "tdx-vtpm"
 path = "src/main.rs"
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.5.2" }
+az-cvm-vtpm = { path = "..", version = "0.5.3" }
 base64-url = "2.0.0"
 bincode.workspace = true
 serde.workspace = true


### PR DESCRIPTION
# Bump SEV crate
This PR will bump the SEV crate to 3.1.1 for use within the github.com/confidential-containers/trustee and github.com/confidential-containers/guest-compoments repos