### PR TITLE
deps: replace rsa crate with openssl

### DIFF
--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-cvm-vtpm"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -23,7 +23,6 @@ bincode.workspace = true
 jsonwebkey = { version = "0.3.5", features = ["pkcs-convert"] }
 memoffset = "0.9.0"
 openssl = { workspace = true, optional = true }
-rsa = { version = "0.9.6", features = ["pkcs5", "sha2"] }
 serde.workspace = true
 serde_json.workspace = true
 serde-big-array = "0.5.1"

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 required-features = ["attester", "verifier"]
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.5.3" }
+az-cvm-vtpm = { path = "..", version = "0.6.0" }
 bincode.workspace = true
 clap.workspace = true
 openssl = { workspace = true, optional = true }

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-tdx-vtpm"
-version = "0.5.3"
+version = "0.6.0"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "tdx-vtpm"
 path = "src/main.rs"
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.5.3" }
+az-cvm-vtpm = { path = "..", version = "0.6.0" }
 base64-url = "3.0.0"
 bincode.workspace = true
 serde.workspace = true

--- a/az-cvm-vtpm/src/hcl/mod.rs
+++ b/az-cvm-vtpm/src/hcl/mod.rs
@@ -146,8 +146,7 @@ impl HclReport {
         }
         let mut hasher = Sha256::new();
         hasher.update(self.var_data_slice());
-        let hash = hasher.finalize();
-        hash.into()
+        hasher.finalize().into()
     }
 
     /// Get the slice of the VarData section

--- a/az-cvm-vtpm/src/vtpm/verify.rs
+++ b/az-cvm-vtpm/src/vtpm/verify.rs
@@ -2,10 +2,8 @@
 // Licensed under the MIT License.
 
 use super::{Quote, QuoteError};
-use openssl::hash::MessageDigest;
 use openssl::pkey::{PKey, Public};
-use openssl::sign::Verifier;
-use sha2::{Digest, Sha256};
+use openssl::{hash::MessageDigest, sha::Sha256, sign::Verifier};
 use thiserror::Error;
 use tss_esapi::structures::{Attest, AttestInfo};
 use tss_esapi::traits::UnMarshall;
@@ -79,7 +77,7 @@ impl Quote {
             hasher.update(pcr);
         }
 
-        let digest = hasher.finalize();
+        let digest = hasher.finish();
         if digest[..] != pcr_digest[..] {
             return Err(VerifyError::PcrMismatch);
         }


### PR DESCRIPTION
# Replace rsa with openssl

fixes #51
fixes #46

We can switch the library to use openssl types also for the attester code. there is a transitive dependency on openssl already inherited from the tss2 tpm library, so we don't win much by not importing openssl in attester code.

The rsa crate is being reported in audit jobs due to a timing-related security issue. The project is not committed to address this in the near time, since the solution involves switching to a big-num dependency with worse security characteristics.

Since this constitutes a breaking API change the minor version has been bumped

## How to use

n/a

## Testing done

Ran the unit tests successfully
