### PR TITLE
Added vTPM get HCL report contains user defined data

### DIFF
--- a/az-cvm-vtpm/src/hcl/mod.rs
+++ b/az-cvm-vtpm/src/hcl/mod.rs
@@ -145,12 +145,12 @@ impl HclReport {
             );
         }
         let mut hasher = Sha256::new();
-        hasher.update(self.var_data_slice());
+        hasher.update(self.var_data());
         hasher.finalize().into()
     }
 
     /// Get the slice of the VarData section
-    fn var_data_slice(&self) -> &[u8] {
+    pub fn var_data(&self) -> &[u8] {
         let var_data_offset =
             offset_of!(AttestationReport, hcl_data) + offset_of!(IgvmRequestData, variable_data);
         let hcl_data = &self.attestation_report.hcl_data;
@@ -160,7 +160,7 @@ impl HclReport {
 
     /// Get the vTPM's AKpub from the VarData section
     pub fn ak_pub(&self) -> Result<JsonWebKey, HclError> {
-        let VarDataKeys { keys } = serde_json::from_slice(self.var_data_slice())?;
+        let VarDataKeys { keys } = serde_json::from_slice(self.var_data())?;
         let ak_pub = keys
             .into_iter()
             .find(|key| {


### PR DESCRIPTION
# Added vTPM get HCL report which allows to include user defined data in retrieved report

- Added temporary limit for max data (50 bytes) - Azure vTPM supports only SHA384 bytes
- Added refresh nvindex method which enables setting user_data field
- Added get HCL report method which uses user provided data and include it in nvindex

## How to use

Sample usage based on az-cvm-vtpm/az-tdx-vtpm/src/main.rs:

```
   let user_hash_64bytes = vec![129, 74, 176, 151, 217, 100, 189, 145, 134, 54, 115, 9, 167, 175, 181, 132, 104, 26, 79, 83, 206, 35, 227, 133, 13, 252, 13, 125, 185, 191, 33, 195, 3, 233, 185, 245, 9, 72, 154, 252, 29, 4, 105, 117, 132, 67, 22, 81, 175, 110, 207, 6, 210, 132, 161, 56, 7, 237, 198, 214, 220, 223, 166, 117];
    println!("user_hash_64bytes HEX: {:?}", hex::encode(&user_hash_64bytes));
    let bytes = vtpm::get_report_with_data(&user_hash_64bytes)?;
```

## Testing done

Tested on virtual machine spawned in Azure by invoking below steps:

1. Updating `az-cvm-vtpm/az-tdx-vtpm/src/main.rs`
2. Compiling code
3. Running sample main
4. Output from library:
`user_hash_64bytes HEX: "814ab097d964bd9186367309a7afb584681a4f53ce23e3850dfc0d7db9bf21c303e9b9f509489afc1d04697584431651af6ecf06d284a13807edc6d6dcdfa675"`
5. Output from TPM2_tools:
Command: ```sudo tpm2_nvread -C o 0x01400001```
Result: 
            ```json
            {
               "keys":[],
               "vm-configuration":{},
               "user-data":"814AB097D964BD9186367309A7AFB584681A4F53CE23E3850DFC0D7DB9BF21C303E9B9F509489AFC1D04697584431651AF6ECF06D284A13807EDC6D6DCDFA675"
            }
            ```
