### PR TITLE
Changed Tss-esapi dependency to be optional

### DIFF
--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -29,13 +29,14 @@ serde-big-array = "0.5.1"
 sev.workspace = true
 sha2 = "0.10.8"
 thiserror.workspace = true
-tss-esapi = "7.5"
+tss-esapi = { version = "7.5.1", optional = true }
 zerocopy.workspace = true
 
 [features]
+tpm = ["tss-esapi"]
 default = ["attester", "verifier"]
-attester = []
-verifier = ["openssl", "sev/openssl"]
+attester = ["tpm"]
+verifier = ["openssl", "sev/openssl", "tpm"]
 
 [workspace.dependencies]
 bincode = "1.3.1"

--- a/az-cvm-vtpm/src/lib.rs
+++ b/az-cvm-vtpm/src/lib.rs
@@ -3,4 +3,5 @@
 
 pub mod hcl;
 pub mod tdx;
+#[cfg(feature = "tpm")]
 pub mod vtpm;


### PR DESCRIPTION
# Changed Tss-esapi dependency to be optional

- Bump: tss-esapi to version 7.5.1
- Tss-esapi dependency is now optional required only for attester and verifier features

## How to use

Cargo.toml
```
[dependencies]
az-cvm-vtpm = { path = "../..", default-features = false }

```
Usage in main.rs

```
use az_cvm_vtpm::hcl;

fn main() {
    println!("bla: {:?}", hcl::ReportType::Tdx);
}
```

## Testing done

1. Checked consistency:
```
cargo fmt --all -- --check
cargo clippy --all-targets --all-features --all -- -D warnings
```

2. Checked with semver-checks
```
cargo semver-checks
     Parsing az-cvm-vtpm v0.6.0 (current)
      Parsed [  17.589s] (current)
     Parsing az-cvm-vtpm v0.6.0 (baseline)
      Parsed [  16.161s] (baseline)
    Checking az-cvm-vtpm v0.6.0 -> v0.6.0 (no change)
     Checked [   0.023s] 89 checks: 88 pass, 1 fail, 0 warn, 0 skip

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/enum_variant_added.ron

Failed in:
  variant ReportError:NvWriteFailed in /azure-cvm-tooling/az-cvm-vtpm/src/vtpm/mod.rs:93

     Summary semver requires new major version: 1 major and 0 minor checks failed
    Finished [  33.792s] az-cvm-vtpm

```

3. Checked CoCo Trustee compilation using patched version