### PR TITLE
Added sleep time to avoid stale report after nvindex update

### DIFF
--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-cvm-vtpm"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 required-features = ["attester", "verifier"]
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.6.0" }
+az-cvm-vtpm = { path = "..", version = "0.7.0" }
 bincode.workspace = true
 clap.workspace = true
 openssl = { workspace = true, optional = true }

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-tdx-vtpm"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "tdx-vtpm"
 path = "src/main.rs"
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.6.0" }
+az-cvm-vtpm = { path = "..", version = "0.7.0" }
 base64-url = "3.0.0"
 bincode.workspace = true
 serde.workspace = true


### PR DESCRIPTION
# Added sleep time (3seconds) to avoid stale report after updating nvindex

Added sleep time to decrease attempts for getting correct nvindex after user data insertion

## Testing done

Tested on Azure environment