### PR TITLE
Update sev to 6.2.1 and adapt to AttestationReport struct changes

### DIFF
--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -45,7 +45,7 @@ openssl = "0.10"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
 thiserror = "2.0.3"
-sev = "5.0.0"
+sev = "6.2.1"
 ureq = { version = "2.6.2", default-features = false, features = ["json"] }
 zerocopy = { version = "0.7.26", features = ["derive"] }
 hex = "0.4"

--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-cvm-vtpm"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-snp-vtpm/example/src/main.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/example/src/main.rs
@@ -85,6 +85,6 @@ fn main() -> Result<(), Box<dyn Error>> {
     let evidence = Attester::gather_evidence(&nonce)?;
     let secret = rp.release_secret(&evidence)?;
 
-    println!("Secret: {}", secret);
+    println!("Secret: {secret}");
     Ok(())
 }

--- a/az-cvm-vtpm/az-snp-vtpm/src/amd_kds.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/src/amd_kds.rs
@@ -51,7 +51,7 @@ fn hexify(bytes: &[u8]) -> String {
 
 /// Retrieve a VCEK cert from AMD's KDS, based on an AttestationReport's platform information
 pub fn get_vcek(report: &AttestationReport) -> Result<Vcek, AmdKdsError> {
-    let hw_id = hexify(&report.chip_id);
+    let hw_id = hexify(&*report.chip_id);
     let url = format!(
         "{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{hw_id}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
         report.reported_tcb.bootloader,

--- a/az-cvm-vtpm/az-snp-vtpm/src/amd_kds.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/src/amd_kds.rs
@@ -44,7 +44,7 @@ pub fn get_cert_chain() -> Result<AmdChain, AmdKdsError> {
 fn hexify(bytes: &[u8]) -> String {
     let mut hex_string = String::new();
     for byte in bytes {
-        hex_string.push_str(&format!("{:02x}", byte));
+        hex_string.push_str(&format!("{byte:02x}"));
     }
     hex_string
 }

--- a/az-cvm-vtpm/az-snp-vtpm/src/main.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/src/main.rs
@@ -68,11 +68,11 @@ fn main() -> Result<(), Box<dyn Error>> {
             snp_report.validate(&vcek)?;
 
             if print {
-                println!("{}", snp_report);
+                println!("{snp_report}");
             }
         }
         Action::Quote { nonce } => {
-            println!("quote byte size: {}", nonce.as_bytes().len());
+            println!("quote byte size: {}", nonce.len());
             let quote = vtpm::get_quote(nonce.as_bytes())?;
             println!("{:02X?}", quote.message());
         }

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-tdx-vtpm"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-tdx-vtpm/src/main.rs
+++ b/az-cvm-vtpm/az-tdx-vtpm/src/main.rs
@@ -12,7 +12,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let td_report: tdx::TdReport = hcl_report.try_into()?;
     assert!(var_data_hash == td_report.report_mac.reportdata[..32]);
-    println!("vTPM AK_pub: {:?}", ak_pub);
+    println!("vTPM AK_pub: {ak_pub:?}");
     let td_quote_bytes = imds::get_td_quote(&td_report)?;
     std::fs::write("td_quote.bin", td_quote_bytes)?;
 


### PR DESCRIPTION
The AttestationReport struct has different sizes and field layouts between sev 4.x and 6.x (new cpuid_fam_id, cpuid_mod_id, cpuid_step fields). Additionally, some fields like chip_id are now wrapped in Array<u8, N> types.

Using bincode serialization results in different byte layouts that break compatibility when upgrading from sev 4.x/5.x to 6.x. The sev 6.x from_bytes() and write_bytes() APIs provide version-aware parsing and serialization that correctly handle different AttestationReport formats (V2, V3-PreTurin, V3-Turin) within the sev 6.x framework. This ensures 
azure-cvm-tooling works correctly after upgrading to sev 6.x despite the underlying AttestationReport struct changes.

This PR fixes the build/test and AttestationReport Parsing issues when upgrading from SEV 4.x/5.x to 6.x.

Changes:
- Replace bincode::deserialize() with AttestationReport::from_bytes()
- Replace bincode::serialize() with AttestationReport::write_bytes()
- Fix chip_id field access with proper dereferencing (&*report.chip_id)

Testing done:
- All cargo build and cargo test pass
- Also verified successfully with trustee-attester build(az-snp-vtpm-attester) and confirmed it can retrieve the key from trustee.
