### PR TITLE
fix: remove unintended `verifier` cfg from AttestationReport export

### DIFF
--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-cvm-vtpm"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-snp-vtpm/src/report.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/src/report.rs
@@ -7,7 +7,6 @@ use az_cvm_vtpm::hcl::{self, HclReport, SNP_REPORT_SIZE};
 use az_cvm_vtpm::vtpm;
 #[cfg(feature = "verifier")]
 use openssl::{ecdsa::EcdsaSig, sha::Sha384};
-#[cfg(feature = "verifier")]
 pub use sev::firmware::guest::AttestationReport;
 use thiserror::Error;
 

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-tdx-vtpm"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"


### PR DESCRIPTION
Previous change (#73 ) deleted `use sev::certs::snp::ecdsa::Signature;` but left `#[cfg(feature = "verifier")]`, unintentionally gating `pub use sev::firmware::guest::AttestationReport;`.

Without this fix, building az-snp-vtpm with `--no-default-features --features attester` fails due to AttestationReport not being in scope, since its import was gated under `#[cfg(feature = "verifier")]`.

Testing done:
 Verified that 'cargo build --no-default-features --features attester' succeeds for az-snp-vtpm after the fix.