### PR TITLE
chore: fix workspace crate revisions

### DIFF
--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-cvm-vtpm"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 required-features = ["attester", "verifier"]
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.7.1" }
+az-cvm-vtpm = { path = "..", version = "0.7.4" }
 bincode.workspace = true
 clap.workspace = true
 openssl = { workspace = true, optional = true }

--- a/az-cvm-vtpm/az-snp-vtpm/src/report.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/src/report.rs
@@ -3,7 +3,9 @@
 
 #[cfg(feature = "verifier")]
 use super::certs::Vcek;
-use az_cvm_vtpm::hcl::{self, HclReport, SNP_REPORT_SIZE};
+#[cfg(feature = "verifier")]
+use az_cvm_vtpm::hcl::SNP_REPORT_SIZE;
+use az_cvm_vtpm::hcl::{self, HclReport};
 use az_cvm_vtpm::vtpm;
 #[cfg(feature = "verifier")]
 use openssl::{ecdsa::EcdsaSig, sha::Sha384};

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-tdx-vtpm"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "tdx-vtpm"
 path = "src/main.rs"
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.7.1" }
+az-cvm-vtpm = { path = "..", version = "0.7.4" }
 base64-url = "3.0.0"
 bincode.workspace = true
 serde.workspace = true


### PR DESCRIPTION
az-{snp,tdx}-vtpm crates were not using an updated az-cvm-vtpm package, resulting in breakage when trying to import either 0.7.3 crate.
