### PR TITLE
Remove bincode dependency

### DIFF
--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -19,7 +19,6 @@ members = [
 path = "src/lib.rs"
 
 [dependencies]
-bincode.workspace = true
 jsonwebkey = { version = "0.3.5", features = ["pkcs-convert"] }
 memoffset = "0.9.0"
 openssl = { workspace = true, optional = true }
@@ -39,13 +38,12 @@ attester = ["tpm"]
 verifier = ["openssl", "sev/openssl", "tpm"]
 
 [workspace.dependencies]
-bincode = "1.3.1"
 clap = { version = "4", features = ["derive"] }
 openssl = "0.10"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
 thiserror = "2.0.3"
-sev = "6.2.1"
+sev = "7"
 ureq = { version = "2.6.2", default-features = false, features = ["json"] }
 zerocopy = { version = "0.8.26", features = ["derive"] }
 hex = "0.4"

--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-cvm-vtpm"
-version = "0.7.4"
+version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -18,7 +18,6 @@ required-features = ["attester", "verifier"]
 
 [dependencies]
 az-cvm-vtpm = { path = "..", version = "0.7.4" }
-bincode.workspace = true
 clap.workspace = true
 openssl = { workspace = true, optional = true }
 serde.workspace = true

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.7.4"
+version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 required-features = ["attester", "verifier"]
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.7.4" }
+az-cvm-vtpm = { path = "..", version = "0.8.0" }
 clap.workspace = true
 openssl = { workspace = true, optional = true }
 serde.workspace = true

--- a/az-cvm-vtpm/az-snp-vtpm/src/amd_kds.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/src/amd_kds.rs
@@ -51,7 +51,7 @@ fn hexify(bytes: &[u8]) -> String {
 
 /// Retrieve a VCEK cert from AMD's KDS, based on an AttestationReport's platform information
 pub fn get_vcek(report: &AttestationReport) -> Result<Vcek, AmdKdsError> {
-    let hw_id = hexify(&*report.chip_id);
+    let hw_id = hexify(&report.chip_id);
     let url = format!(
         "{KDS_CERT_SITE}{KDS_VCEK}/{SEV_PROD_NAME}/{hw_id}?blSPL={:02}&teeSPL={:02}&snpSPL={:02}&ucodeSPL={:02}",
         report.reported_tcb.bootloader,

--- a/az-cvm-vtpm/az-snp-vtpm/src/report.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/src/report.rs
@@ -3,13 +3,12 @@
 
 #[cfg(feature = "verifier")]
 use super::certs::Vcek;
-#[cfg(feature = "verifier")]
-use az_cvm_vtpm::hcl::SNP_REPORT_SIZE;
 use az_cvm_vtpm::hcl::{self, HclReport};
 use az_cvm_vtpm::vtpm;
 #[cfg(feature = "verifier")]
 use openssl::{ecdsa::EcdsaSig, sha::Sha384};
 pub use sev::firmware::guest::AttestationReport;
+use sev::parser::ByteParser;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -23,8 +22,6 @@ pub enum ValidateError {
     MeasurementSignature,
     #[error("IO error")]
     Io(#[from] std::io::Error),
-    #[error("bincode error")]
-    Bincode(#[from] Box<bincode::ErrorKind>),
 }
 
 #[cfg(feature = "verifier")]
@@ -57,7 +54,7 @@ impl Validateable for AttestationReport {
 #[derive(Error, Debug)]
 pub enum ReportError {
     #[error("deserialization error")]
-    Parse(#[from] Box<bincode::ErrorKind>),
+    InvalidSize,
     #[error("vTPM error")]
     Vtpm(#[from] vtpm::ReportError),
     #[error("HCL error")]
@@ -67,8 +64,7 @@ pub enum ReportError {
 pub fn parse(bytes: &[u8]) -> Result<AttestationReport, ReportError> {
     // Use the sev's from_bytes method(since sev-6) which handles dynamic parsing
     // of different SNP report versions (v2, v3-PreTurin, v3-Turin)
-    let snp_report = AttestationReport::from_bytes(bytes)
-        .map_err(|e| ReportError::Parse(Box::new(bincode::ErrorKind::Io(e))))?;
+    let snp_report = AttestationReport::from_bytes(bytes).map_err(|_e| ReportError::InvalidSize)?;
     Ok(snp_report)
 }
 
@@ -78,14 +74,10 @@ fn is_tcb_data_valid(report: &AttestationReport) -> bool {
 }
 
 #[cfg(feature = "verifier")]
-fn get_report_base(report: &AttestationReport) -> Result<Vec<u8>, Box<bincode::ErrorKind>> {
-    // Use sev's write_bytes method (since SEV-6) for serializing SNP reports to ensure full compatibility
-    // Original bincode::serialize + size_of calculation is inaccurate on SEV 6.x
-    let mut raw_bytes = Vec::with_capacity(SNP_REPORT_SIZE);
-    report
-        .write_bytes(&mut raw_bytes)
-        .map_err(|e| Box::new(bincode::ErrorKind::Io(e)))?;
-    let report_bytes_without_sig = &raw_bytes[0..0x2a0];
+fn get_report_base(report: &AttestationReport) -> Result<Vec<u8>, ValidateError> {
+    // Use sev's to_bytes method (since SEV-7) for serializing SNP reports to ensure full compatibility
+    let raw_bytes = report.to_bytes().map_err(ValidateError::Io)?;
+    let report_bytes_without_sig = &raw_bytes[..0x2a0];
     Ok(report_bytes_without_sig.to_vec())
 }
 

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/main.rs"
 [dependencies]
 az-cvm-vtpm = { path = "..", version = "0.7.4" }
 base64-url = "3.0.0"
-bincode.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-tdx-vtpm"
-version = "0.7.4"
+version = "0.8.0"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "tdx-vtpm"
 path = "src/main.rs"
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.7.4" }
+az-cvm-vtpm = { path = "..", version = "0.8.0" }
 base64-url = "3.0.0"
 serde.workspace = true
 serde_json.workspace = true

--- a/az-cvm-vtpm/az-tdx-vtpm/src/report.rs
+++ b/az-cvm-vtpm/az-tdx-vtpm/src/report.rs
@@ -1,13 +1,13 @@
 use crate::hcl::{self, HclReport};
 use crate::tdx::TdReport;
 use crate::vtpm;
-use bincode::deserialize;
 use thiserror::Error;
+use zerocopy::FromBytes;
 
 #[derive(Error, Debug)]
 pub enum ReportError {
     #[error("deserialization error")]
-    Parse(#[from] Box<bincode::ErrorKind>),
+    InvalidSize,
     #[error("vTPM error")]
     Vtpm(#[from] vtpm::ReportError),
     #[error("HCL error")]
@@ -16,7 +16,8 @@ pub enum ReportError {
 
 /// Parse raw bytes into TdReport
 pub fn parse(bytes: &[u8]) -> Result<TdReport, ReportError> {
-    deserialize::<TdReport>(bytes).map_err(|e| e.into())
+    let cursor = bytes;
+    TdReport::read_from_bytes(cursor).map_err(|_| ReportError::InvalidSize)
 }
 
 /// Fetch TdReport from vTPM and parse it

--- a/az-cvm-vtpm/src/hcl/mod.rs
+++ b/az-cvm-vtpm/src/hcl/mod.rs
@@ -5,13 +5,14 @@ use crate::tdx::TdReport;
 use jsonwebkey::JsonWebKey;
 use memoffset::offset_of;
 use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
 use sev::firmware::guest::AttestationReport as SnpReport;
+use sev::parser::ByteParser;
 use sha2::{Digest, Sha256};
 use std::convert::TryFrom;
 use std::mem::size_of;
 use std::ops::Range;
 use thiserror::Error;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 const HCL_AKPUB_KEY_ID: &str = "HCLAkPub";
 const TD_REPORT_SIZE: usize = size_of::<TdReport>();
@@ -37,12 +38,12 @@ const SNP_REPORT_RANGE: Range<usize> = report_range(SNP_REPORT_SIZE);
 
 #[derive(Error, Debug)]
 pub enum HclError {
+    #[error("invalid report size")]
+    InvalidReportSize,
     #[error("invalid report type")]
     InvalidReportType,
     #[error("AkPub not found")]
     AkPubNotFound,
-    #[error("binary parse error")]
-    BinaryParseError(#[from] bincode::Error),
     #[error("JSON parse error")]
     JsonParseError(#[from] serde_json::Error),
 }
@@ -62,18 +63,18 @@ enum IgvmHashType {
 }
 
 #[repr(C)]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq, FromBytes, Immutable, IntoBytes)]
 struct IgvmRequestData {
     data_size: u32,
     version: u32,
     report_type: u32,
-    report_data_hash_type: IgvmHashType,
+    report_data_hash_type: u32,
     variable_data_size: u32,
     variable_data: [u8; 0],
 }
 
 #[repr(C)]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq, FromBytes, Immutable, IntoBytes)]
 struct AttestationHeader {
     signature: u32,
     version: u32,
@@ -84,10 +85,9 @@ struct AttestationHeader {
 }
 
 #[repr(C)]
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, PartialEq, FromBytes, Immutable, IntoBytes)]
 struct AttestationReport {
     header: AttestationHeader,
-    #[serde(with = "BigArray")]
     hw_report: [u8; MAX_REPORT_SIZE],
     hcl_data: IgvmRequestData,
 }
@@ -113,7 +113,27 @@ pub enum HwReport {
 impl HclReport {
     /// Parse a HCL report from a byte slice.
     pub fn new(bytes: Vec<u8>) -> Result<Self, HclError> {
-        let attestation_report: AttestationReport = bincode::deserialize(&bytes)?;
+        const STRUCT_SIZE: usize = std::mem::size_of::<AttestationReport>();
+
+        if bytes.len() < STRUCT_SIZE {
+            return Err(HclError::InvalidReportSize);
+        }
+
+        // Read fixed struct using zerocopy
+        let struct_bytes = &bytes[..STRUCT_SIZE];
+        let cursor = struct_bytes;
+        let attestation_report =
+            AttestationReport::read_from_bytes(cursor).map_err(|_| HclError::InvalidReportSize)?;
+
+        // Validate variable data size if present
+        let var_data_size = attestation_report.hcl_data.variable_data_size as usize;
+        if var_data_size > 0 {
+            let var_data_end = STRUCT_SIZE + var_data_size;
+            if bytes.len() < var_data_end {
+                return Err(HclError::InvalidReportSize);
+            }
+        }
+
         let report_type = match attestation_report.hcl_data.report_type {
             TDX_REPORT_TYPE => ReportType::Tdx,
             SNP_REPORT_TYPE => ReportType::Snp,
@@ -142,9 +162,9 @@ impl HclReport {
 
     /// Get the SHA256 hash of the VarData section
     pub fn var_data_sha256(&self) -> [u8; 32] {
-        if self.attestation_report.hcl_data.report_data_hash_type != IgvmHashType::Sha256 {
+        if self.attestation_report.hcl_data.report_data_hash_type != IgvmHashType::Sha256 as u32 {
             unimplemented!(
-                "Only SHA256 is supported, got {:?}",
+                "Only SHA256 is supported, got hash type {}",
                 self.attestation_report.hcl_data.report_data_hash_type
             );
         }
@@ -186,7 +206,10 @@ impl TryFrom<&HclReport> for TdReport {
             return Err(HclError::InvalidReportType);
         }
         let bytes = hcl_report.report_slice();
-        let td_report = bincode::deserialize::<TdReport>(bytes)?;
+        // Use zerocopy for safe casting - read_from_bytes consumes the bytes and handles large arrays
+        let cursor = bytes;
+        let td_report =
+            TdReport::read_from_bytes(cursor).map_err(|_| HclError::InvalidReportSize)?;
         Ok(td_report)
     }
 }
@@ -209,8 +232,7 @@ impl TryFrom<&HclReport> for SnpReport {
         let bytes = hcl_report.report_slice();
         // Use the sev-6.x crate's from_bytes method which handles dynamic parsing
         // of different SNP report versions (v2, v3-PreTurin, v3-Turin)
-        let snp_report = SnpReport::from_bytes(bytes)
-            .map_err(|e| HclError::BinaryParseError(Box::new(bincode::ErrorKind::Io(e))))?;
+        let snp_report = SnpReport::from_bytes(bytes).map_err(|_e| HclError::InvalidReportType)?;
         Ok(snp_report)
     }
 }

--- a/az-cvm-vtpm/src/tdx/mod.rs
+++ b/az-cvm-vtpm/src/tdx/mod.rs
@@ -4,12 +4,10 @@
 // Types are based on "Architecture Specification: Intel Trust Domain Extensions
 // Module 1.0", Feb 2023, Section 22.6
 
-use serde::{Deserialize, Serialize};
-use serde_big_array::BigArray;
-use zerocopy::{Immutable, IntoBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 #[repr(C)]
-#[derive(Immutable, IntoBytes, Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(FromBytes, Immutable, IntoBytes, Copy, Clone, Debug, PartialEq)]
 pub struct ReportType {
     pub r#type: u8,
     pub subtype: u8,
@@ -18,51 +16,41 @@ pub struct ReportType {
 }
 
 #[repr(C)]
-#[derive(Immutable, IntoBytes, Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(FromBytes, Immutable, IntoBytes, Copy, Clone, Debug, PartialEq)]
 pub struct ReportMac {
     pub reporttype: ReportType,
     pub _reserved_1: [u8; 12],
     pub cpusvn: [u8; 16],
-    #[serde(with = "BigArray")]
     pub tee_tcb_info_hash: [u8; 48],
-    #[serde(with = "BigArray")]
     pub tee_info_hash: [u8; 48],
-    #[serde(with = "BigArray")]
     pub reportdata: [u8; 64],
     pub _reserved_2: [u8; 32],
     pub mac: [u8; 32],
 }
 
 #[repr(C)]
-#[derive(Immutable, IntoBytes, Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(FromBytes, Immutable, IntoBytes, Copy, Clone, Debug, PartialEq)]
 pub struct Rtmr {
-    #[serde(with = "BigArray")]
     pub register_data: [u8; 48],
 }
 
 #[repr(C)]
-#[derive(Immutable, IntoBytes, Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(FromBytes, Immutable, IntoBytes, Copy, Clone, Debug, PartialEq)]
 pub struct TdInfo {
     pub attributes: [u8; 8],
     pub xfam: [u8; 8],
-    #[serde(with = "BigArray")]
     pub mrtd: [u8; 48],
-    #[serde(with = "BigArray")]
     pub mrconfigid: [u8; 48],
-    #[serde(with = "BigArray")]
     pub mrowner: [u8; 48],
-    #[serde(with = "BigArray")]
     pub mrownerconfig: [u8; 48],
     pub rtmr: [Rtmr; 4],
-    #[serde(with = "BigArray")]
     pub _reserved: [u8; 112],
 }
 
 #[repr(C)]
-#[derive(Immutable, IntoBytes, Copy, Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(FromBytes, Immutable, IntoBytes, Copy, Clone, Debug, PartialEq)]
 pub struct TdReport {
     pub report_mac: ReportMac,
-    #[serde(with = "BigArray")]
     pub tee_tcb_info: [u8; 239],
     pub _reserved: [u8; 17],
     pub tdinfo: TdInfo,

--- a/az-cvm-vtpm/src/vtpm/verify.rs
+++ b/az-cvm-vtpm/src/vtpm/verify.rs
@@ -90,10 +90,61 @@ impl Quote {
 mod tests {
     use super::*;
 
+    /// Deserialize Quote from binary format
+    /// The test fixture is stored in a binary format that was previously bincode-encoded.
+    /// This deserializer reconstructs the Quote struct from the binary data.
+    fn deserialize_quote(data: &[u8]) -> Result<Quote, String> {
+        use std::io::{Cursor, Read};
+
+        let mut cursor = Cursor::new(data);
+
+        // Read signature (Vec<u8>)
+        let mut signature_len_bytes = [0u8; 8];
+        cursor
+            .read_exact(&mut signature_len_bytes)
+            .map_err(|e| format!("Failed to read signature length: {e}"))?;
+        let signature_len = u64::from_le_bytes(signature_len_bytes) as usize;
+        let mut signature = vec![0u8; signature_len];
+        cursor
+            .read_exact(&mut signature)
+            .map_err(|e| format!("Failed to read signature: {e}"))?;
+
+        // Read message (Vec<u8>)
+        let mut message_len_bytes = [0u8; 8];
+        cursor
+            .read_exact(&mut message_len_bytes)
+            .map_err(|e| format!("Failed to read message length: {e}"))?;
+        let message_len = u64::from_le_bytes(message_len_bytes) as usize;
+        let mut message = vec![0u8; message_len];
+        cursor
+            .read_exact(&mut message)
+            .map_err(|e| format!("Failed to read message: {e}"))?;
+
+        // Read pcrs (Vec<[u8; 32]>)
+        let mut pcrs_len_bytes = [0u8; 8];
+        cursor
+            .read_exact(&mut pcrs_len_bytes)
+            .map_err(|e| format!("Failed to read pcrs length: {e}"))?;
+        let pcrs_len = u64::from_le_bytes(pcrs_len_bytes) as usize;
+        let mut pcrs = Vec::with_capacity(pcrs_len);
+        for _ in 0..pcrs_len {
+            let mut pcr = [0u8; 32];
+            cursor
+                .read_exact(&mut pcr)
+                .map_err(|e| format!("Failed to read pcr: {e}"))?;
+            pcrs.push(pcr);
+        }
+
+        Ok(Quote {
+            signature,
+            message,
+            pcrs,
+        })
+    }
+
     // // Use this code to generate the scriptures for the test on an AMD CVM.
     //
     // use az_snp_vtpm::vtpm;
-    // use bincode;
     // use rsa;
     // use rsa::pkcs8::EncodePublicKey;
     // use std::error::Error;
@@ -128,7 +179,8 @@ mod tests {
         // For PCR values:
         // sudo tpm2_pcrread sha256:0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23
         let quote_bytes = include_bytes!("../../test/quote.bin");
-        let quote: Quote = bincode::deserialize(quote_bytes).unwrap();
+        // Using custom deserializer to read the test fixture
+        let quote: Quote = deserialize_quote(quote_bytes).expect("Failed to deserialize quote");
 
         // proper nonce in message
         let nonce = "challenge".as_bytes().to_vec();
@@ -158,7 +210,8 @@ mod tests {
     #[test]
     fn test_pcr_values() {
         let quote_bytes = include_bytes!("../../test/quote.bin");
-        let quote: Quote = bincode::deserialize(quote_bytes).unwrap();
+        // Using custom deserializer to read the test fixture
+        let quote: Quote = deserialize_quote(quote_bytes).expect("Failed to deserialize quote");
         let result = quote.verify_pcrs();
         assert!(result.is_ok(), "PCR verification should not fail");
     }


### PR DESCRIPTION
This commit removes dependency on the unmaintained bincode crate which was flagged by cargo deny advisory RUSTSEC-2025-0141.

Changes made:

1. **Upgraded sev dependency** (6.2.1 → 7.1.0)
   - sev v7 no longer depends on bincode
   - Added ByteParser import for API compatibility

2. **Migrated to zerocopy for hardware protocol parsing**
   - All repr(C) structures now use zerocopy::FromBytes/ToBytes
   - Zero-copy safe casting for SNP reports, TDX reports, vTPM quotes
   - Custom serialize/deserialize for variable sized HclReport fields and quote

Tested with:
   cargo test --workspace

Fixes:
https://github.com/kinvolk/azure-cvm-tooling/issues/84
