### PR TITLE
release 0.8.1

### DIFF
--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -43,7 +43,7 @@ openssl = "0.10"
 serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
 thiserror = "2.0.3"
-sev = "7"
+sev = { version = "7", default-features = false, features = ["snp"] }
 ureq = { version = "2.6.2", default-features = false, features = ["json"] }
 zerocopy = { version = "0.8.26", features = ["derive"] }
 hex = "0.4"

--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -44,6 +44,6 @@ serde = { version = "1.0.189", features = ["derive"] }
 serde_json = "1.0.107"
 thiserror = "2.0.3"
 sev = { version = "7", default-features = false, features = ["snp"] }
-ureq = { version = "2.6.2", default-features = false, features = ["json"] }
+ureq = { version = "3.2.0", default-features = false, features = ["json"] }
 zerocopy = { version = "0.8.26", features = ["derive"] }
 hex = "0.4"

--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-cvm-vtpm"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -32,5 +32,5 @@ hex.workspace = true
 [features]
 default = ["attester", "verifier"]
 attester = []
-verifier = ["az-cvm-vtpm/openssl", "openssl", "ureq/tls"]
+verifier = ["az-cvm-vtpm/openssl", "openssl", "ureq/native-tls", "ureq/json"]
 integration_test = []

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 required-features = ["attester", "verifier"]
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.8.0" }
+az-cvm-vtpm = { path = "..", version = "0.8.1" }
 clap.workspace = true
 openssl = { workspace = true, optional = true }
 serde.workspace = true

--- a/az-cvm-vtpm/az-snp-vtpm/src/amd_kds.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/src/amd_kds.rs
@@ -5,6 +5,7 @@ use crate::certs::{AmdChain, Vcek};
 use crate::HttpError;
 use openssl::x509::X509;
 use sev::firmware::guest::AttestationReport;
+use std::io::Read;
 use thiserror::Error;
 
 const KDS_CERT_SITE: &str = "https://kdsintf.amd.com";
@@ -13,9 +14,9 @@ const SEV_PROD_NAME: &str = "Milan";
 const KDS_CERT_CHAIN: &str = "cert_chain";
 
 fn get(url: &str) -> Result<Vec<u8>, HttpError> {
-    let mut body = ureq::get(url).call().map_err(Box::new)?.into_reader();
+    let mut res = ureq::get(url).call().map_err(Box::new)?;
     let mut buffer = Vec::new();
-    body.read_to_end(&mut buffer)?;
+    res.body_mut().as_reader().read_to_end(&mut buffer)?;
     Ok(buffer)
 }
 

--- a/az-cvm-vtpm/az-snp-vtpm/src/certs.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/src/certs.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use openssl::asn1::Asn1Time;
 pub use openssl::x509::X509;
 use thiserror::Error;
 
@@ -17,7 +18,7 @@ pub enum ValidateError {
     ArkNotSelfSigned,
     #[error("ASK is not signed by ARK")]
     AskNotSignedByArk,
-    #[error("VCEK is not signed by ASK")]
+    #[error("VCEK is not signed by ASK (or not valid at verification time)")]
     VcekNotSignedByAsk,
 }
 
@@ -54,6 +55,12 @@ impl Vcek {
             return Err(ValidateError::VcekNotSignedByAsk);
         }
 
+        let now = Asn1Time::days_from_now(0)?;
+        let valid_range = self.0.not_before()..self.0.not_after();
+        if !valid_range.contains(&now) {
+            return Err(ValidateError::VcekNotSignedByAsk);
+        }
+
         Ok(())
     }
 }
@@ -85,15 +92,74 @@ pub fn build_cert_chain(pem: &str) -> Result<AmdChain, ParseError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::certs::{AmdChain, Vcek};
+    use openssl::asn1::Asn1Time;
+    use openssl::ec::{EcGroup, EcKey};
+    use openssl::hash::MessageDigest;
+    use openssl::nid::Nid;
+    use openssl::pkey::PKey;
+    use openssl::x509::{X509Builder, X509NameBuilder};
 
-    #[test]
-    fn test_validate_certificates() {
+    fn build_dummy_chain() -> (Vcek, AmdChain) {
+        let group = EcGroup::from_curve_name(Nid::SECP384R1).unwrap();
+        let ec_key = EcKey::generate(&group).unwrap();
+        let pkey = PKey::from_ec_key(ec_key).unwrap();
+
+        let mut name_builder = X509NameBuilder::new().unwrap();
+        name_builder
+            .append_entry_by_text("CN", "test-expired")
+            .unwrap();
+        let name = name_builder.build();
+
+        let mut builder = X509Builder::new().unwrap();
+        builder.set_subject_name(&name).unwrap();
+        builder.set_issuer_name(&name).unwrap();
+        builder.set_pubkey(&pkey).unwrap();
+        let not_before = Asn1Time::from_str("20200101000000Z").unwrap();
+        let not_after = Asn1Time::from_str("20210101000000Z").unwrap();
+        builder.set_not_before(&not_before).unwrap();
+        builder.set_not_after(&not_after).unwrap();
+        builder.sign(&pkey, MessageDigest::sha384()).unwrap();
+        let expired_cert = builder.build();
+
+        let vcek = Vcek(expired_cert);
+        let chain = AmdChain {
+            ask: vcek.0.clone(),
+            ark: vcek.0.clone(),
+        };
+        (vcek, chain)
+    }
+
+    fn build_chain_from_pem() -> (Vcek, AmdChain) {
         let bytes = include_bytes!("../../test/certs.pem");
         let certs = X509::stack_from_pem(bytes).unwrap();
         let (vcek, ask, ark) = (certs[0].clone(), certs[1].clone(), certs[2].clone());
         let vcek = Vcek(vcek);
         let cert_chain = AmdChain { ask, ark };
-        cert_chain.validate().unwrap();
-        vcek.validate(&cert_chain).unwrap();
+        (vcek, cert_chain)
+    }
+
+    #[test]
+    fn test_validate_certificates() {
+        // test valid chain
+        let (vcek, mut chain) = build_chain_from_pem();
+        chain.validate().unwrap();
+        vcek.validate(&chain).unwrap();
+
+        // test invalid chain
+        chain.ark = chain.ask.clone();
+        let result = chain.validate();
+        assert!(
+            result.is_err(),
+            "should fail validation since ASK is not self-signed"
+        );
+
+        // test expired vcek
+        let (expired_vcek, chain) = build_dummy_chain();
+        let result = expired_vcek.validate(&chain);
+        assert!(
+            result.is_err(),
+            "should fail validation for expired certificate"
+        );
     }
 }

--- a/az-cvm-vtpm/az-snp-vtpm/src/imds.rs
+++ b/az-cvm-vtpm/az-snp-vtpm/src/imds.rs
@@ -19,9 +19,11 @@ pub struct Certificates {
 /// **Note:** this can only be called from a Confidential VM.
 pub fn get_certs() -> Result<Certificates, HttpError> {
     let res: Certificates = ureq::get(IMDS_CERT_URL)
-        .set("Metadata", "true")
+        .header("Metadata", "true")
         .call()
         .map_err(Box::new)?
-        .into_json()?;
+        .body_mut()
+        .read_json()
+        .map_err(Box::new)?;
     Ok(res)
 }

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-tdx-vtpm"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "tdx-vtpm"
 path = "src/main.rs"
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.8.0" }
+az-cvm-vtpm = { path = "..", version = "0.8.1" }
 base64-url = "3.0.0"
 serde.workspace = true
 serde_json.workspace = true

--- a/az-cvm-vtpm/az-tdx-vtpm/src/imds.rs
+++ b/az-cvm-vtpm/az-tdx-vtpm/src/imds.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use az_cvm_vtpm::tdx::TdReport;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use zerocopy::IntoBytes;
 
@@ -18,6 +18,7 @@ pub enum ImdsError {
     IoError(#[from] std::io::Error),
 }
 
+#[derive(Serialize)]
 struct ReportBody {
     report: String,
 }
@@ -40,11 +41,11 @@ pub fn get_td_quote(td_report: &TdReport) -> Result<Vec<u8>, ImdsError> {
     let bytes = td_report.as_bytes();
     let report_body = ReportBody::new(bytes);
     let response: QuoteResponse = ureq::post(IMDS_QUOTE_URL)
-        .send_json(ureq::json!({
-            "report": report_body.report,
-        }))
+        .send_json(&report_body)
         .map_err(Box::new)?
-        .into_json()?;
+        .body_mut()
+        .read_json()
+        .map_err(Box::new)?;
     let quote = base64_url::decode(&response.quote)?;
     Ok(quote)
 }

--- a/az-cvm-vtpm/src/vtpm/mod.rs
+++ b/az-cvm-vtpm/src/vtpm/mod.rs
@@ -311,6 +311,11 @@ impl Quote {
         self.pcrs.iter()
     }
 
+    /// Extract signature from a Quote
+    pub fn signature(&self) -> Vec<u8> {
+        self.signature.clone()
+    }
+
     /// Extract nonce from a Quote
     pub fn nonce(&self) -> Result<Vec<u8>, QuoteError> {
         let attest = Attest::unmarshall(&self.message)?;


### PR DESCRIPTION
# Some smaller non-breaking changes 

- bump ureq crate to 3.2.0
- security fix: verify validity range of vcek
- signature() on tpm Quote struct
- use only the "snp" feature of the sev crate (unbreaks compilation on non x86_64 targets)

## How to use

```
cargo t --all --features verifier,attester -q
```

## Testing done

ran unit tests and cargo semver-checks
