### PR TITLE
Propagate default-features = false on az-cvm-vtpm dep

### DIFF
--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 required-features = ["attester", "verifier"]
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.8.1" }
+az-cvm-vtpm = { path = "..", version = "0.8.1", default-features = false, features = ["attester"] }
 clap.workspace = true
 openssl = { workspace = true, optional = true }
 serde.workspace = true
@@ -32,5 +32,5 @@ hex.workspace = true
 [features]
 default = ["attester", "verifier"]
 attester = []
-verifier = ["az-cvm-vtpm/openssl", "openssl", "ureq/native-tls", "ureq/json"]
+verifier = ["az-cvm-vtpm/verifier", "openssl", "ureq/native-tls", "ureq/json"]
 integration_test = []

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -16,7 +16,7 @@ name = "tdx-vtpm"
 path = "src/main.rs"
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.8.1" }
+az-cvm-vtpm = { path = "..", version = "0.8.1", default-features = false, features = ["attester"] }
 base64-url = "3.0.0"
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Problem

`az-snp-vtpm` and `az-tdx-vtpm` depend on `az-cvm-vtpm` without `default-features = false`, so `az-cvm-vtpm`'s default `verifier` feature is **always** enabled for any consumer — even one that explicitly sets `default-features = false, features = ["attester"]` on the vTPM crate. Cargo unifies features by union, so a top-level consumer cannot disable a default feature enabled by an intermediate dependent.

Because `az-cvm-vtpm`'s `verifier` activates `sev/openssl`, and `virtee/sev` v7 [refuses to compile with both `openssl` and `crypto_nossl` enabled](https://github.com/virtee/sev/releases/tag/v7.1.0), attester-only consumers cannot combine these crates with a `sev = { features = ["crypto_nossl"] }` elsewhere in the dependency graph — for example, projects that also ship a WASM verifier build using `sev/crypto_nossl`. Build fails with:

```
error[E0119]: conflicting implementations of trait `certs::snp::Verifiable`
error[E0252]: the name `Certificate` is defined multiple times
error[E0599]: no method named `public_key_sec1` found for reference `&cert::Certificate`
```

## Fix

On both `az-snp-vtpm` and `az-tdx-vtpm`:

```toml
az-cvm-vtpm = { path = "..", version = "0.8.1", default-features = false, features = ["attester"] }
```

`features = ["attester"]` keeps the shared attester code always on (it's needed by the vTPM crates' own library code), while `verifier` becomes opt-in.

`az-snp-vtpm`'s `verifier` feature now propagates `az-cvm-vtpm/verifier` directly. Previously it activated `az-cvm-vtpm/openssl` (the auto-generated feature for the optional `openssl` dep), which only activated the full verifier path transitively because `verifier` was also in `az-cvm-vtpm`'s default set. Under `default-features = false` that indirect route breaks; the explicit propagation becomes load-bearing. `az-tdx-vtpm`'s `verifier` already propagates correctly and needs no change.

## Verification

With the patch applied (verified via `cargo tree`):

- `az-snp-vtpm` **default** build → `openssl` present in normal deps (verifier path active, no behavioral change).
- `az-snp-vtpm --no-default-features --features attester` → **0** `openssl` refs in normal deps.
- Same pattern for `az-tdx-vtpm`.

Default consumers see no change. Attester-only consumers no longer pull `sev/openssl` transitively, unblocking sev 7 + `crypto_nossl` combinations.

## Context

Downstream: [lunal-dev/attestation-rs](https://github.com/lunal-dev/attestation-rs) ships a verifier that targets WASM (`sev/crypto_nossl`) and uses `az-snp-vtpm` / `az-tdx-vtpm` as Linux attesters. Currently working around this by moving the vTPM crates behind opt-in Cargo features so they never enter the common attest build graph ([PR #32](https://github.com/lunal-dev/attestation-rs/pull/32)). This upstream fix would let us collapse that split back into a single `attest` feature.

Related prior issues: #68, #70 (sev version axis). This one is on the feature-propagation axis.