### PR TITLE
tdx/imds: Fix td_quote retrieval header

### DIFF
--- a/az-cvm-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-cvm-vtpm"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"

--- a/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-snp-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-snp-vtpm"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -17,7 +17,7 @@ path = "src/main.rs"
 required-features = ["attester", "verifier"]
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.8.1", default-features = false, features = ["attester"] }
+az-cvm-vtpm = { path = "..", version = "0.8.2", default-features = false, features = ["attester"] }
 clap.workspace = true
 openssl = { workspace = true, optional = true }
 serde.workspace = true

--- a/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
+++ b/az-cvm-vtpm/az-tdx-vtpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "az-tdx-vtpm"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 repository = "https://github.com/kinvolk/azure-cvm-tooling/"
 license = "MIT"
@@ -16,7 +16,7 @@ name = "tdx-vtpm"
 path = "src/main.rs"
 
 [dependencies]
-az-cvm-vtpm = { path = "..", version = "0.8.1", default-features = false, features = ["attester"] }
+az-cvm-vtpm = { path = "..", version = "0.8.2", default-features = false, features = ["attester"] }
 base64-url = "3.0.0"
 serde.workspace = true
 serde_json.workspace = true

--- a/az-cvm-vtpm/az-tdx-vtpm/src/imds.rs
+++ b/az-cvm-vtpm/az-tdx-vtpm/src/imds.rs
@@ -25,7 +25,7 @@ struct ReportBody {
 
 impl From<ReportBody> for String {
     fn from(val: ReportBody) -> Self {
-        format!(r#"{{"report":"{}"}}"#, val.report)
+        serde_json::json!({ "report": val.report }).to_string()
     }
 }
 

--- a/az-cvm-vtpm/az-tdx-vtpm/src/imds.rs
+++ b/az-cvm-vtpm/az-tdx-vtpm/src/imds.rs
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 use az_cvm_vtpm::tdx::TdReport;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use std::convert::From;
 use thiserror::Error;
 use zerocopy::IntoBytes;
 
@@ -18,9 +19,14 @@ pub enum ImdsError {
     IoError(#[from] std::io::Error),
 }
 
-#[derive(Serialize)]
 struct ReportBody {
     report: String,
+}
+
+impl From<ReportBody> for String {
+    fn from(val: ReportBody) -> Self {
+        format!(r#"{{"report":"{}"}}"#, val.report)
+    }
 }
 
 impl ReportBody {
@@ -40,12 +46,16 @@ struct QuoteResponse {
 pub fn get_td_quote(td_report: &TdReport) -> Result<Vec<u8>, ImdsError> {
     let bytes = td_report.as_bytes();
     let report_body = ReportBody::new(bytes);
-    let response: QuoteResponse = ureq::post(IMDS_QUOTE_URL)
-        .send_json(&report_body)
-        .map_err(Box::new)?
-        .body_mut()
-        .read_json()
+    let raw_body: String = report_body.into();
+    let mut response = ureq::post(IMDS_QUOTE_URL)
+        .header("Metadata", "true")
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .send(raw_body)
         .map_err(Box::new)?;
+
+    let response: QuoteResponse = response.body_mut().read_json().map_err(Box::new)?;
     let quote = base64_url::decode(&response.quote)?;
+
     Ok(quote)
 }


### PR DESCRIPTION
# TDX: Fix td_quote retrieval from IMDS

The IMDS endpoint to retrieve a quote doesn't accept the header that ureq 3.x produces for json:

"application/json; charset=utf-8"

it needs to be

"application/json"

Otherwise the endpoint will respond with a 415 Unknown media type status code.

We define the headers explicitly and also add a "Metadata: true" header which is good practice for IMDS endpoints.

## How to use

n/a

## Testing done

Manually on TDX (Standard_DC2es_v6)

In mkulke/trustee:

```
cargo build -p kbs --release --no-default-features --features coco-as-builtin
cargo build -p kbs-client --release --features az-tdx-vtpm-attester
mkdir -p config work
cat <<EOF> ./config/kbs-insecure.toml
[http_server]
insecure_http = true

[attestation_token]
insecure_header_jwk = true

[attestation_service]
type = "coco_as_builtin"

[attestation_service.attestation_token_broker]
duration_min = 5

[attestation_service.rvps_config]
type = "BuiltIn"

[admin]
authorization_mode = "InsecureAllowAll"

# Unified storage backend configuration
[storage_backend]
storage_type = "LocalFs"

[storage_backend.backends.local_fs]
dir_path = "./work/storage"

# Optional session storage type override.
# If omitted, KBS falls back to [storage_backend].storage_type.
# Backend-specific config is always reused from [storage_backend.backends].
# Session state is stored under namespace: "kbs_protocol_session".
#
# session_storage_type = "Memory"

[[plugins]]
name = "resource"
storage_backend_type = "kvstorage"
EOF

openssl genrsa -traditional -out work/tee.key 2048

RUST_LOG=verifier=debug ./kbs --config-file config/kbs-insecure.toml

RUST_LOG=attester=debug,ureq::run=debug sudo -E ./kbs-client --url http://127.0.0.1:8080 attest --tee-key-file work/tee.key > work/attestation_token
```